### PR TITLE
Show only vertical scroll

### DIFF
--- a/css/emoji-mart.css
+++ b/css/emoji-mart.css
@@ -68,7 +68,7 @@
 }
 
 .emoji-mart-scroll {
-  overflow: scroll;
+  overflow-y: scroll;
   height: 270px;
   padding: 0 6px 6px 6px;
   border: solid #d9d9d9;


### PR DESCRIPTION
Some OS (Linux, Windows) still have ugly big scrollbars. Let’s remove horizontal scroll.

Before:

![szq55m3](https://cloud.githubusercontent.com/assets/19343/19728502/e7b21570-9b93-11e6-8864-b34d39dda89b.png)

After:

![hues6ga](https://cloud.githubusercontent.com/assets/19343/19728504/eda7f670-9b93-11e6-86e8-34d6c76d8d3c.png)
