### PR TITLE
Isolate .emoji-mart-anchors from page line-height

### DIFF
--- a/css/emoji-mart.css
+++ b/css/emoji-mart.css
@@ -31,6 +31,7 @@
   justify-content: space-between;
   padding: 0 6px;
   color: #858585;
+  line-height: 0;
 }
 
 .emoji-mart-anchor {


### PR DESCRIPTION
On our web site picker is looked like:

![gkzyfht](https://cloud.githubusercontent.com/assets/19343/19854491/49a6f170-9f80-11e6-854f-6a33f9957d08.png)

(Note about spaces under category icons)

It happens because some of webpage styles inherits to component. Here we have a problem because of inherited `line-height` (we set it to 1.4).

This fix override problem.

(I wait until all browsers will support `all: initial`, so we will be able to do inherit properties isolation better).