### PR TITLE
Allow custom namespace for store

### DIFF
--- a/src/utils/store.js
+++ b/src/utils/store.js
@@ -1,4 +1,4 @@
-const NAMESPACE = 'emoji-mart'
+var NAMESPACE = 'emoji-mart'
 
 var isLocalStorageSupported = typeof window !== 'undefined' &&
                               'localStorage' in window
@@ -24,4 +24,8 @@ function get(key) {
   }
 }
 
-export default { update, set, get }
+function setNamespace(namespace){
+	NAMESPACE = namespace
+}
+
+export default { update, set, get, setNamespace }


### PR DESCRIPTION
In multi-user environment (for example, Electron app), it would be nice for users to have separate 'frequently used' emoji lists.

This commits adds `setNamespace({string} namespace)` function to store module, so developer can set it to appropriate value after new user has been signed in.
