### PR TITLE
Allow passing children to Emoji component

### DIFF
--- a/src/components/emoji.js
+++ b/src/components/emoji.js
@@ -62,7 +62,7 @@ export default class Emoji extends React.Component {
     var { set, size, sheetSize, native, onOver, onLeave, backgroundImageFn } = this.props,
         { unified } = this.getData(),
         style = {},
-        children = null
+        children = this.props.children
 
     if (!unified) {
       return null


### PR DESCRIPTION
When use inside of an editor, it's useful to be able to pass children down to the Emoji component in order to be able to use the custom images and not break editing