### PR TITLE
Fix issue with operator in skin tone logic

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -27,7 +27,7 @@ function sanitize(emoji) {
     name,
     colons,
     emoticons,
-    skin: skin_tone || skin_variations ? 1 : null,
+    skin: skin_tone || (skin_variations ? 1 : null),
     native: unifiedToNative(unified),
   }
 }


### PR DESCRIPTION
`||` has a higher precedence than conditional operator (`? ... :`). Fixed by surrounding with parentheses. 