### PR TITLE
wrap localStorage access in try-catch

### DIFF
--- a/src/utils/store.js
+++ b/src/utils/store.js
@@ -12,12 +12,19 @@ function update(state) {
 
 function set(key, value) {
   if (!isLocalStorageSupported) return
-  window.localStorage[`${NAMESPACE}.${key}`] = JSON.stringify(value)
+  try {
+    window.localStorage[`${NAMESPACE}.${key}`] = JSON.stringify(value)
+  } catch (e) {
+  }
 }
 
 function get(key) {
   if (!isLocalStorageSupported) return
-  var value = window.localStorage[`${NAMESPACE}.${key}`]
+  try {
+    var value = window.localStorage[`${NAMESPACE}.${key}`]
+  } catch (e) {
+    return
+  }
 
   if (value) {
     return JSON.parse(value)


### PR DESCRIPTION
Many browsers may support localStorage, but disable access to it in certain situations. For example, Safari private browsing mode will raise an exception if you try to access localStorage from a third-party domain, resulting in unhandled errors like...

> QuotaExceededError: DOM Exception 22: An attempt was made to add something to storage that exceeded the quota.

The easiest way to handle this for optional features is to simply try-catch all access to localStorage.