### PR TITLE
Preserve height and width on svgs

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = {
       },
       {
         test: /\.svg$/,
-        loader: 'svg-inline',
+        loader: 'svg-inline?removeSVGTagAttrs=false',
         include: [
           path.resolve('src/svgs'),
         ],


### PR DESCRIPTION
We discovered an IE11 bug that would expand the height of SVGs. The solution was to not remove the height and width attributes from the SVG element.