### PR TITLE
allow style overrides from user

### DIFF
--- a/src/components/picker.js
+++ b/src/components/picker.js
@@ -242,7 +242,7 @@ export default class Picker extends React.Component {
         { skin } = this.state,
         width = (perLine * (emojiSize + 12)) + 12 + 2
 
-    return <div style={{...style, width: width}} className='emoji-mart'>
+    return <div style={{width: width, ...style}} className='emoji-mart'>
       <div className='emoji-mart-bar'>
         <Anchors
           ref='anchors'


### PR DESCRIPTION
Change order of style merge, so the width can be overridden to for example '100%'.

Suggested change is because I need the picker to have a width of 100% of the parent.