### PR TITLE
Fix categories on IE11

### DIFF
--- a/src/components/picker.js
+++ b/src/components/picker.js
@@ -180,7 +180,7 @@ export default class Picker extends React.Component {
       let component = this.refs[`category-${i}`]
 
       if (component && component.props.name != 'Search') {
-        let display = emojis ? 'none' : null
+        let display = emojis ? 'none' : 'inherit'
         component.updateDisplay(display)
       }
     }


### PR DESCRIPTION
This patch fixes an issue in Internet Explorer where clicking the category after entering something in the search bar would result in no visible behavior.