### PR TITLE
use img for emojis to make them selectable and copyable using the alt attribute

### DIFF
--- a/css/emoji-mart.css
+++ b/css/emoji-mart.css
@@ -15,7 +15,7 @@
 }
 
 .emoji-mart .emoji-mart-emoji {
-  padding: 6px;
+  margin: 6px;
 }
 
 .emoji-mart-bar:first-child {
@@ -88,7 +88,7 @@
   outline: 0;
 }
 
-.emoji-mart-category .emoji-mart-emoji span {
+.emoji-mart-category .emoji-mart-emoji {
   z-index: 1;
   position: relative;
   text-align: center;
@@ -126,6 +126,7 @@
   position: relative;
   display: inline-block;
   font-size: 0;
+  content: url('data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==');
 }
 
 .emoji-mart-no-results {

--- a/src/components/emoji.js
+++ b/src/components/emoji.js
@@ -63,8 +63,7 @@ export default class Emoji extends React.Component {
   render() {
     var { set, size, sheetSize, native, forceSize, onOver, onLeave, backgroundImageFn } = this.props,
         { unified } = this.getData(),
-        style = {},
-        children = this.props.children
+        style = {}
 
     if (!unified) {
       return null
@@ -72,7 +71,6 @@ export default class Emoji extends React.Component {
 
     if (native && unified) {
       style = { fontSize: size }
-      children = unifiedToNative(unified)
 
       if (forceSize) {
         style.display = 'inline-block'
@@ -90,13 +88,13 @@ export default class Emoji extends React.Component {
       }
     }
 
-    return <span
+    return <img
+      alt={this.props.alt}
       onClick={this.handleClick.bind(this)}
       onMouseEnter={this.handleOver.bind(this)}
       onMouseLeave={this.handleLeave.bind(this)}
-      className='emoji-mart-emoji'>
-      <span style={style}>{children}</span>
-    </span>
+      className='emoji-mart-emoji'
+      style={style} />
   }
 }
 


### PR DESCRIPTION
This commit uses img for emojis to make them selectable and copyable using the alt attribute. It helps a lot when the Emoji class is re-used for chat applications, so that users can copy an emoji instead of look it up. 

Correct me if I'm wrong but this sort of thing isn't possible with span as far as I know, I could at best manage to make the text within the span be copied, but the selection never highlights it.