### PR TITLE
Installation instructions & stylesheet corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
   <br>Brought to you by the <a title="Team email, team chat, team tasks, one app" href="https://missiveapp.com">Missive</a> team
 </div>
 
+## Installation
+
+`npm install --save emoji-mart`
+
 ## Components
 ### Picker
 ```jsx

--- a/css/emoji-mart.css
+++ b/css/emoji-mart.css
@@ -163,7 +163,7 @@
 
 .emoji-mart-preview-data {
   left: 68px; right: 12px;
-  word-break: break-word;
+  word-break: break-all;
 }
 
 .emoji-mart-preview-skins {
@@ -231,7 +231,7 @@
   transition-timing-function: ease-out;
 }
 
-.emoji-mart-skin-swatch:nth-child(1) { transition-delay: 0 }
+.emoji-mart-skin-swatch:nth-child(1) { transition-delay: 0s }
 .emoji-mart-skin-swatch:nth-child(2) { transition-delay: .03s }
 .emoji-mart-skin-swatch:nth-child(3) { transition-delay: .06s }
 .emoji-mart-skin-swatch:nth-child(4) { transition-delay: .09s }


### PR DESCRIPTION
1. introduce npm install instructions. Can be inferred but if you're like me, the first you do when trying new tools is `command + f` npm install

2. `word-break` was set to an invalid parameter

3. Mismatched property value threw an error in my text editor, so i fixed it