### PR TITLE
Allow preview emoji to be hidden.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ import { Picker } from 'emoji-mart'
 | ---- | :------: | ------- | ----------- |
 | **autoFocus** | | `false` | Auto focus the search input when mounted |
 | **color** | | `#ae65c5` | The top bar anchors select and hover color |
-| **emoji** | | `department_store` | The emoji shown when no emojis are hovered |
+| **emoji** | | `department_store` | The emoji shown when no emojis are hovered, set to an empty string to show nothing |
 | **include** | | `[]` | Only load included categories. Accepts [I18n categories keys](#i18n). Order will be respected, except for the `recent` category which will always be the first. |
 | **exclude** | | `[]` | Don't load excluded categories. Accepts [I18n categories keys](#i18n). |
 | **emojiSize** | | `24` | The emoji width and height |

--- a/src/components/preview.js
+++ b/src/components/preview.js
@@ -53,10 +53,10 @@ export default class Preview extends React.Component {
     } else {
       return <div className='emoji-mart-preview'>
         <div className='emoji-mart-preview-emoji'>
-          <Emoji
+          {idleEmoji.length > 0 && <Emoji
             emoji={idleEmoji}
             {...emojiProps}
-          />
+          />}
         </div>
 
         <div className='emoji-mart-preview-data'>


### PR DESCRIPTION
When no emoji is being hovered, the default preview is shown (currently `department_store`).

By setting the `emoji` argument to an empty string, this fallback can be disabled.

This means that something will only show when an emoji is hovered.

This means that when both `emoji` and `title` are set to empty strings, the footer area will be empty.