### PR TITLE
Make custom emojis work on example page

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -199,7 +199,7 @@ class Example extends React.Component {
 <Operator>import</Operator> &#123;Emoji&#125; <Operator>from</Operator> <String>'emoji-mart'</String>
 <br />
 <br /><Operator>&lt;</Operator><Variable>Emoji</Variable>
-<br />  emoji<Operator>=</Operator><String>'thumbsup'</String>
+<br />  emoji<Operator>=</Operator><String>'{this.state.currentEmoji}'</String>
 <br />  size<Operator>=</Operator>&#123;<Variable>{64}</Variable>&#125;
 <br /><Operator>/&gt;</Operator>
         </pre>

--- a/example/index.js
+++ b/example/index.js
@@ -182,7 +182,7 @@ class Example extends React.Component {
           include={this.state.include}
           exclude={this.state.exclude}
           onClick={(emoji) => {
-            this.setState({ currentEmoji: emoji.id })
+            this.setState({ currentEmoji: emoji.custom ? emoji : emoji.id })
             console.log(emoji)
           }}
         />
@@ -199,7 +199,7 @@ class Example extends React.Component {
 <Operator>import</Operator> &#123;Emoji&#125; <Operator>from</Operator> <String>'emoji-mart'</String>
 <br />
 <br /><Operator>&lt;</Operator><Variable>Emoji</Variable>
-<br />  emoji<Operator>=</Operator><String>'{this.state.currentEmoji}'</String>
+<br />  emoji<Operator>=</Operator>{this.state.currentEmoji.custom ? (<Variable>{'{…}'}</Variable>) : (<String>'{this.state.currentEmoji}'</String>)}
 <br />  size<Operator>=</Operator>&#123;<Variable>{64}</Variable>&#125;
 <br /><Operator>/&gt;</Operator>
         </pre>

--- a/example/index.js
+++ b/example/index.js
@@ -229,7 +229,7 @@ class Example extends React.Component {
 
         <span style={{ display: 'inline-block', marginTop: 40 }}>
           {Emoji({
-            emoji: `:${this.state.currentEmoji}:`,
+            emoji: ':thumbsup:',
             size: 64,
             set: this.state.set,
           })}
@@ -252,7 +252,7 @@ class Example extends React.Component {
 
         <span style={{ display: 'inline-block', marginTop: 40 }}>
           {Emoji({
-            emoji: `:${this.state.currentEmoji}::skin-tone-3:`,
+            emoji: ':thumbsup::skin-tone-3:',
             size: 64,
             set: this.state.set,
           })}
@@ -276,7 +276,7 @@ class Example extends React.Component {
 
         <span style={{ display: 'inline-block', marginTop: 60 }}>
           {Emoji({
-            emoji: `:${this.state.currentEmoji}::skin-tone-3:`,
+            emoji: ':thumbsup::skin-tone-3:',
             size: 64,
             native: true,
           })}


### PR DESCRIPTION
In addition to making custom emojis work on the example page, only the first `<Emoji />` example is now updated with the clicked emoji. I thought this would be the best solution as custom emojis won’t work with the rest of the examples (besides, not all emojis support the skin tone modifier, too).

Aside from that, the code example next to the displayed emoji is now updated with the actual `emoji.id` (or `{…}` in the case of custom emojis).