### PR TITLE
Text representation of emoji is different from emoticon

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,12 @@ Sheets are served from [unpkg](https://unpkg.com), a global CDN that serves file
   id: 'smiley',
   name: 'Smiling Face with Open Mouth',
   colons: ':smiley:',
+  text: ':)',
   emoticons: [
     '=)',
     '=-)'
   ],
-  skin: null,
+  skin: null,  
   native: '😃'
 }
 
@@ -102,6 +103,7 @@ Sheets are served from [unpkg](https://unpkg.com), a global CDN that serves file
   id: 'santa',
   name: 'Father Christmas',
   colons: ':santa::skin-tone-3:',
+  text: '',
   emoticons: [],
   skin: 3,
   native: '🎅🏼'
@@ -111,6 +113,7 @@ Sheets are served from [unpkg](https://unpkg.com), a global CDN that serves file
   id: 'octocat',
   name: 'Octocat',
   colons: ':octocat',
+  text: '',
   emoticons: [],
   custom: true,
   imageUrl: 'https://assets-cdn.github.com/images/icons/emoji/octocat.png?v7'
@@ -150,6 +153,7 @@ const customEmojis = [
   {
     name: 'Octocat',
     short_names: ['octocat'],
+    text: '',
     emoticons: [],
     keywords: ['github'],
     imageUrl: 'https://assets-cdn.github.com/images/icons/emoji/octocat.png?v7'

--- a/scripts/build-data.js
+++ b/scripts/build-data.js
@@ -42,11 +42,7 @@ emojiData.forEach((datum) => {
   }
 
   datum.emoticons = datum.texts || []
-  if (datum.text && !datum.emoticons.length) {
-    datum.emoticons = [datum.text]
-  }
-
-  delete datum.text
+  datum.text = datum.text || ''
   delete datum.texts
 
   if (emojiLib.lib[datum.short_name]) {


### PR DESCRIPTION
Emoji-data provides the ascii representation of the emoji, available under `text`. The emoticons are in the `texts` field. 

From the README for the `texts` field: *Each ASCII emoji will only appear against a single emoji entry*. This guarantees that an emoticon will map to a single emoji. 

The current version uses the ascii representation when no emoticon is available for an emoji, which leads to invalid results when looking up an emoticon. For example, `:)` returns `:blush:` and `:slightly_smiling_face:` where there should only be a single match `:slightly_smiling_face:`

I kept the ascii representation in the data since it might be useful to render a text-only version of the emoji.