### PR TITLE
Search/defaultValue: first pass

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -43,6 +43,7 @@ class Example extends React.Component {
       hidden: false,
       currentEmoji: { id: '+1' },
       autoFocus: false,
+      defaultValue: '',
       include: [],
       exclude: [],
     }
@@ -68,6 +69,9 @@ class Example extends React.Component {
       } else {
         state[key] = checked
       }
+    } else if (type === 'text') {
+      var { value } = currentTarget
+      state[key] = value
     } else {
       var { value } = currentTarget
       state[key] = parseInt(value)
@@ -143,6 +147,7 @@ class Example extends React.Component {
 <br />  set<Operator>=</Operator><String>'{this.state.set}'</String>
 <br />  custom<Operator>=</Operator>&#123;<Variable>{'[…]'}</Variable>&#125;
 <br />  autoFocus<Operator>=</Operator>&#123;<Variable>{this.state.autoFocus ? 'true' : 'false'}</Variable>&#125;{this.state.autoFocus ? ' ' : ''} <input type='checkbox' data-key='autoFocus' data-mount={true} onChange={this.handleInput.bind(this)} checked={this.state.autoFocus} />
+<br />  defaultValue<Operator>=</Operator>&#123;<input data-key='defaultValue' data-mount={true} size={this.state.defaultValue.length + 1} value={this.state.defaultValue} onChange={this.handleInput.bind(this)} />&#125;
 <div style={{ opacity: this.state.exclude.length ? 0.6 : 1 }}>  include<Operator>=</Operator>&#91;
 {[0, 2, 4, 6, 8].map((i) => {
   let category1 = CATEGORIES[i],
@@ -179,6 +184,7 @@ class Example extends React.Component {
           set={this.state.set}
           custom={CUSTOM_EMOJIS}
           autoFocus={this.state.autoFocus}
+          defaultValue={this.state.defaultValue}
           include={this.state.include}
           exclude={this.state.exclude}
           onClick={(emoji) => {

--- a/src/components/picker.js
+++ b/src/components/picker.js
@@ -328,7 +328,7 @@ export default class Picker extends React.Component {
   }
 
   render() {
-    var { perLine, emojiSize, set, sheetSize, style, title, emoji, color, native, backgroundImageFn, emojisToShowFilter, include, exclude, autoFocus } = this.props,
+    var { perLine, emojiSize, set, sheetSize, style, title, emoji, color, native, backgroundImageFn, emojisToShowFilter, include, exclude, autoFocus, defaultValue } = this.props,
         { skin } = this.state,
         width = (perLine * (emojiSize + 12)) + 12 + 2 + measureScrollbar()
 
@@ -343,16 +343,20 @@ export default class Picker extends React.Component {
         />
       </div>
 
-      <Search
-        ref='search'
-        onSearch={this.handleSearch.bind(this)}
-        i18n={this.i18n}
-        emojisToShowFilter={emojisToShowFilter}
-        include={include}
-        exclude={exclude}
-        custom={CUSTOM_CATEGORY.emojis}
-        autoFocus={autoFocus}
-      />
+      {/* don't render Search until Categories are rendered and searchable */}
+      {this.state.firstRender ? null :
+        <Search
+          ref='search'
+          onSearch={this.handleSearch.bind(this)}
+          i18n={this.i18n}
+          emojisToShowFilter={emojisToShowFilter}
+          include={include}
+          exclude={exclude}
+          custom={CUSTOM_CATEGORY.emojis}
+          autoFocus={autoFocus}
+          defaultValue={this.state.firstRender ? undefined : defaultValue}
+        />
+      }
 
       <div ref="scroll" className='emoji-mart-scroll' onScroll={this.handleScroll.bind(this)}>
         {this.getCategories().map((category, i) => {
@@ -423,6 +427,7 @@ Picker.propTypes = {
   include: PropTypes.arrayOf(PropTypes.string),
   exclude: PropTypes.arrayOf(PropTypes.string),
   autoFocus: PropTypes.bool,
+  defaultValue: PropTypes.string,
   custom: PropTypes.arrayOf(PropTypes.shape({
     name: PropTypes.string.isRequired,
     short_names: PropTypes.arrayOf(PropTypes.string).isRequired,

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -20,8 +20,18 @@ export default class Search extends React.Component {
     this.refs.input.value = ''
   }
 
+  componentDidMount() {
+    // setTimeout queues task to happen after React finishes whatever render loop it's in
+    // this prevents Search Results AND regular categories from coinciding
+    // more info on this trick:
+    //   * http://stackoverflow.com/q/2723610/249801
+    //   * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout#Late_timeouts
+    //   * https://jakearchibald.com/2015/tasks-microtasks-queues-and-schedules/
+    if (this.props.defaultValue) setTimeout(this.handleChange.bind(this))
+  }
+
   render() {
-    var { i18n, autoFocus } = this.props
+    var { i18n, autoFocus, defaultValue } = this.props
 
     return <div className='emoji-mart-search'>
       <input
@@ -30,6 +40,7 @@ export default class Search extends React.Component {
         onChange={this.handleChange.bind(this)}
         placeholder={i18n.search}
         autoFocus={autoFocus}
+        defaultValue={defaultValue}
       />
     </div>
   }
@@ -40,6 +51,7 @@ Search.propTypes = {
   maxResults: PropTypes.number,
   emojisToShowFilter: PropTypes.func,
   autoFocus: PropTypes.bool,
+  defaultValue: PropTypes.string,
 }
 
 Search.defaultProps = {


### PR DESCRIPTION
Ref: #95

Getting this to render properly seems like it takes more effort than it may be worth. Additionally, this causes the following error several times on re-render (like, say, when checking the 'autofocus' checkbox on the demo):

    Warning: flattenChildren(...): Encountered two children with the
      same key, `Custom`. Child keys must be unique; when two children
      share a key, only the first child will be used.

I have so far been unable to figure out why my change causes this error. However, as re-rendering will not happen as much under normal circumstances, maybe it doesn't matter.