### PR TITLE
Reduce npm package size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,7 @@
 scripts/
 .*
+
+src/
+example/
+karma.conf.js
+yarn.lock


### PR DESCRIPTION
In this PR I *do not* reduce library size. I reduced only npm package size. It is important too because in our days many developers complain about big `node_modules` size.

I added test and build files to npm ignore.