### PR TITLE
Babel fixes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,11 @@
 {
   "presets": ["es2015", "react"],
-  "plugins": ["transform-object-rest-spread", "transform-runtime", "transform-react-remove-prop-types"]
+  "plugins": [
+    "transform-object-rest-spread",
+    "transform-runtime",
+    "transform-react-remove-prop-types",
+    [
+      "transform-define", "scripts/define.js"
+    ]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "rimraf": "2.5.2",
-    "size-limit": "^0.10.0",
+    "size-limit": "^0.11.1",
     "svg-jsx-loader": "^0.0.16",
     "webpack": "1.12.14"
   },
@@ -71,7 +71,7 @@
   "size-limit": [
     {
       "path": "dist/index.js",
-      "limit": "110 KB"
+      "limit": "105 KB"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "size-limit": [
     {
       "path": "dist/index.js",
-      "limit": "105 KB"
+      "limit": "99 KB"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-cli": "^6.26.0",
     "babel-core": "6.7.2",
     "babel-loader": "6.2.4",
+    "babel-plugin-transform-define": "^1.3.0",
     "babel-plugin-transform-es2015-destructuring": "6.9.0",
     "babel-plugin-transform-object-rest-spread": "6.8.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.8",

--- a/scripts/build-data.js
+++ b/scripts/build-data.js
@@ -141,8 +141,8 @@ flags.emojis.sort()
 mkdirp('data', (err) => {
   if (err) throw err
 
-  const stringifiedData = JSON.stringify(data).replace(/\"([A-Za-z_]+)\":/g, '$1:')
-  fs.writeFile('data/index.js', `export default ${stringifiedData}`, (err) => {
+  const stringified = JSON.stringify(data).replace(/\"([A-Za-z_]+)\":/g, '$1:')
+  fs.writeFile('data/index.js', `module.exports = ${stringified}`, (err) => {
     if (err) throw err
   })
 })

--- a/scripts/define.js
+++ b/scripts/define.js
@@ -1,0 +1,6 @@
+var pack = require('../package.json')
+
+module.exports = {
+  'process.env.NODE_ENV': 'production',
+  EMOJI_DATASOURCE_VERSION: pack.devDependencies['emoji-datasource']
+}

--- a/src/utils/emoji-index.js
+++ b/src/utils/emoji-index.js
@@ -1,5 +1,3 @@
-const extend = require('util')._extend
-
 import data from '../../data'
 import { getData, getSanitizedData, intersect } from '.'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1047,9 +1047,9 @@ bytes@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339"
 
-bytes@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.5.0.tgz#4c9423ea2d252c270c41b2bdefeff9bb6b62c06a"
+bytes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
 
 cacache@^9.2.9:
   version "9.2.9"
@@ -1430,9 +1430,9 @@ css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
 
-css-loader@^0.28.4:
-  version "0.28.4"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-0.28.4.tgz#6cf3579192ce355e8b38d5f42dd7a1f2ec898d0f"
+css-loader@^0.28.7:
+  version "0.28.7"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-0.28.7.tgz#5f2ee989dd32edd907717f953317656160999c1b"
   dependencies:
     babel-code-frame "^6.11.0"
     css-selector-tokenizer "^0.7.0"
@@ -1447,7 +1447,7 @@ css-loader@^0.28.4:
     postcss-modules-scope "^1.0.0"
     postcss-modules-values "^1.1.0"
     postcss-value-parser "^3.3.0"
-    source-list-map "^0.1.7"
+    source-list-map "^2.0.0"
 
 css-selector-tokenizer@^0.7.0:
   version "0.7.0"
@@ -2241,6 +2241,13 @@ gzip-size@^3.0.0:
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-3.0.0.tgz#546188e9bdc337f673772f81660464b389dce520"
   dependencies:
     duplexer "^0.1.1"
+
+gzip-size@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-4.0.0.tgz#a80e13e18938bcb2e6702fec606f5cf8b666db3a"
+  dependencies:
+    duplexer "^0.1.1"
+    pify "^3.0.0"
 
 har-schema@^1.0.5:
   version "1.0.5"
@@ -3388,6 +3395,10 @@ pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -4154,23 +4165,24 @@ signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-size-limit@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/size-limit/-/size-limit-0.10.0.tgz#ab9ae1935198896ee5117fe3d6e6a3f042a1500e"
+size-limit@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/size-limit/-/size-limit-0.11.1.tgz#e3f5f3ea67671203a716358af0e483de28ff0e3d"
   dependencies:
-    bytes "^2.5.0"
+    bytes "^3.0.0"
     chalk "^2.1.0"
     ci-job-number "^0.3.0"
     compression-webpack-plugin "^1.0.0"
-    css-loader "^0.28.4"
+    css-loader "^0.28.7"
+    escape-string-regexp "^1.0.5"
     file-loader "^0.11.2"
     globby "^6.1.0"
-    gzip-size "^3.0.0"
+    gzip-size "^4.0.0"
     memory-fs "^0.4.1"
     read-pkg-up "^2.0.0"
     style-loader "^0.18.2"
     uglifyjs-webpack-plugin "^1.0.0-beta.2"
-    webpack "^3.5.4"
+    webpack "^3.5.6"
     webpack-bundle-analyzer "^2.9.0"
     yargs "^8.0.2"
 
@@ -4234,13 +4246,13 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
-source-list-map@^0.1.7, source-list-map@~0.1.7:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.8.tgz#c550b2ab5427f6b3f21f5afead88c4f5587b2106"
-
 source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
+
+source-list-map@~0.1.7:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.8.tgz#c550b2ab5427f6b3f21f5afead88c4f5587b2106"
 
 source-map-support@^0.4.15:
   version "0.4.17"
@@ -4815,9 +4827,9 @@ webpack@1.12.14:
     watchpack "^0.2.1"
     webpack-core "~0.6.0"
 
-webpack@^3.5.4:
-  version "3.5.5"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.5.5.tgz#3226f09fc8b3e435ff781e7af34f82b68b26996c"
+webpack@^3.5.6:
+  version "3.5.6"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.5.6.tgz#a492fb6c1ed7f573816f90e00c8fbb5a20cc5c36"
   dependencies:
     acorn "^5.0.0"
     acorn-dynamic-import "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -490,6 +490,13 @@ babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
+babel-plugin-transform-define@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-define/-/babel-plugin-transform-define-1.3.0.tgz#94c5f9459c810c738cc7c50cbd44a31829d6f319"
+  dependencies:
+    lodash "4.17.4"
+    traverse "0.6.6"
+
 babel-plugin-transform-es2015-arrow-functions@^6.3.13:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz#452692cb711d5f79dc7f85e440ce41b9f244d221"
@@ -2815,13 +2822,13 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
+lodash@4.17.4, lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.5.0:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
 lodash@^3.10.0, lodash@^3.5.0, lodash@^3.8.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
-
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.5.0:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
 log4js@^0.6.31:
   version "0.6.38"
@@ -4547,6 +4554,10 @@ tough-cookie@~2.3.0:
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
   dependencies:
     punycode "^1.4.1"
+
+traverse@0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
 
 trim-right@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
1. Fixed missed `EMOJI_DATASOURCE_VERSION` from previous “Webpack → Babel” PR.
2. `data/index.js` now use ES5 exports, so we don’t need Babel for it.
3. I removed unnecessary `util` import and reduce EmojiMart size above 100KB.

/cc @davojta @EtienneLem