### PR TITLE
Use will-change:transform for smoother mobile scrolling

### DIFF
--- a/css/emoji-mart.css
+++ b/css/emoji-mart.css
@@ -79,6 +79,7 @@
   overflow-y: scroll;
   height: 270px;
   padding: 0 6px 6px 6px;
+  will-change: transform; /* avoids "repaints on scroll" in mobile Chrome */
 }
 
 .emoji-mart-search {


### PR DESCRIPTION
This improves mobile scrolling, [especially on mobile Chrome/Android](https://stackoverflow.com/a/41026886/680742). It provides a hint to the browser to move the scrollable element to a layer on the GPU, which leads to visibly smoother scrolling in Chrome/Android.

Chrome also warns about this in the Dev Tools:

![out](https://user-images.githubusercontent.com/283842/30775640-f6d20c4a-a04c-11e7-9282-06294cc5f34d.png)

Here's a video showing the before and after (note some overall lag due to using Android `screenrecord` plus DevTools being attached; the "after" version is even smoother without those things): https://gfycat.com/DamagedDistinctHorsechestnutleafminer