### PR TITLE
Build as ES module as well as CommonJS

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,7 +12,6 @@
     "transform-es2015-for-of",
     "transform-es2015-function-name",
     "transform-es2015-literals",
-    "transform-es2015-modules-commonjs",
     "transform-es2015-object-super",
     "transform-es2015-parameters",
     "transform-es2015-shorthand-properties",
@@ -40,5 +39,12 @@
         }
       }
     ]
-  ]
+  ],
+  "env": {
+    "cjs": {
+      "plugins": [
+        "transform-es2015-modules-commonjs"
+      ]
+    }
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
+dist-es/
 bundle.js

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.1",
   "description": "Customizable Slack-like emoji picker for React",
   "main": "dist/index.js",
+  "module": "dist-es/index.js",
   "repository": {
     "type": "git",
     "url": "git@github.com:missive/emoji-mart.git"
@@ -61,11 +62,13 @@
     "webpack": "^3.6.0"
   },
   "scripts": {
-    "clean": "rm -rf dist/",
+    "clean": "rm -rf dist/ dist-es/",
     "build:data": "node scripts/build-data",
-    "build:dist": "npm run clean && babel src --out-dir dist --copy-files --ignore webpack.config.js",
+    "build:dist": "npm run clean && npm run build:cjs && npm run build:es",
+    "build:cjs": "BABEL_ENV=cjs babel src --out-dir dist --copy-files --ignore webpack.config.js",
+    "build:es": "babel src --out-dir dist-es --copy-files --ignore webpack.config.js",
     "build": "npm run build:dist && npm run build:data",
-    "watch": "babel src --watch --out-dir dist --copy-files --ignore webpack.config.js",
+    "watch": "BABEL_ENV=cjs babel src --watch --out-dir dist --copy-files --ignore webpack.config.js",
     "start": "npm run watch",
     "stats": "webpack --config ./src/webpack.config.js --json > stats.json",
     "react:clean": "rimraf node_modules/{react,react-dom,react-addons-test-utils}",

--- a/scripts/build-data.js
+++ b/scripts/build-data.js
@@ -143,4 +143,7 @@ flags.emojis = flags.emojis.filter((flag) => {
 const stringified = JSON.stringify(data).replace(/\"([A-Za-z_]+)\":/g, '$1:')
 fs.writeFile('dist/data/data.js', `module.exports = ${stringified}`, (err) => {
   if (err) throw err
+  fs.writeFile('dist-es/data/data.js', `export default ${stringified}`, (err) => {
+    if (err) throw err
+  })
 })

--- a/src/polyfills/createClass.js
+++ b/src/polyfills/createClass.js
@@ -1,6 +1,6 @@
 const _Object = Object
 
-module.exports = function createClass() {
+export default (function createClass() {
   function defineProperties(target, props) {
     for (var i = 0; i < props.length; i++) {
       var descriptor = props[i];
@@ -16,4 +16,4 @@ module.exports = function createClass() {
     if (staticProps) defineProperties(Constructor, staticProps);
     return Constructor;
   };
-}();
+}());

--- a/src/polyfills/extends.js
+++ b/src/polyfills/extends.js
@@ -1,6 +1,6 @@
 const _Object = Object
 
-module.exports = _Object.assign || function (target) {
+export default _Object.assign || function (target) {
   for (var i = 1; i < arguments.length; i++) {
     var source = arguments[i];
 

--- a/src/polyfills/inherits.js
+++ b/src/polyfills/inherits.js
@@ -1,6 +1,6 @@
 const _Object = Object
 
-module.exports = function inherits(subClass, superClass) {
+export default function inherits(subClass, superClass) {
   if (typeof superClass !== "function" && superClass !== null) {
     throw new TypeError("Super expression must either be null or a function, not " + typeof superClass);
   }

--- a/src/polyfills/objectGetPrototypeOf.js
+++ b/src/polyfills/objectGetPrototypeOf.js
@@ -1,6 +1,6 @@
 const _Object = Object
 
-module.exports = _Object.getPrototypeOf || function (O) {
+export default _Object.getPrototypeOf || function (O) {
   O = Object(O)
 
   if (typeof O.constructor === 'function' && O instanceof O.constructor) {

--- a/src/polyfills/possibleConstructorReturn.js
+++ b/src/polyfills/possibleConstructorReturn.js
@@ -1,4 +1,4 @@
-module.exports = function possibleConstructorReturn(self, call) {
+export default function possibleConstructorReturn(self, call) {
   if (!self) {
     throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
   }

--- a/src/polyfills/stringFromCodePoint.js
+++ b/src/polyfills/stringFromCodePoint.js
@@ -1,6 +1,6 @@
 const _String = String
 
-module.exports = _String.fromCodePoint || function stringFromCodePoint() {
+export default _String.fromCodePoint || function stringFromCodePoint() {
   var MAX_SIZE = 0x4000;
   var codeUnits = [];
   var highSurrogate;

--- a/src/utils/build-search.js
+++ b/src/utils/build-search.js
@@ -1,4 +1,4 @@
-module.exports = data => {
+export default data => {
   const search = []
 
   var addToSearch = (strings, split) => {


### PR DESCRIPTION
I can see this project is in active development, but I thought this PR may be useful to you, even just as a proof of concept.

In the [Mastodon](https://github.com/tootsuite/mastodon) project we are currently integrating `emoji-mart`, but we'd like to avoid the situation where we need to load the entire module (921kB) for all users. We use `emojiIndex` extensively, but the picker itself is only needed on-demand. So in principle, if `emoji-mart` were distributed as an ES module (with `"module"` declared in `package.json`), then we'd be able to do:

```js
import { emojiIndex } from 'emoji-picker'
```

...and [Webpack tree-shaking](https://webpack.js.org/guides/tree-shaking/) would take care of the rest.

I'm not sure if the current master is a good representation of what you intend to ship in `dist` (e.g. with raw `.svg` files?), but if so then this PR would be a reasonable approach to build both CommonJS and ES modules. Essentially it builds a `dist/cjs` directory (referenced by `"main"` in `package.json`) and then also a `dist/es` directory (referenced by `"module"` in `packagejson`). Webpack 2+ should pick up on the `"module"` version and thus allow for tree-shaking.