### PR TITLE
Bug Fix: Ensure category ids are not dropped after emojisToShowFilter call

### DIFF
--- a/spec/picker-spec.js
+++ b/spec/picker-spec.js
@@ -33,5 +33,11 @@ describe('Picker', () => {
       subject = render({ emojisToShowFilter: unified => false })
       expect(subject.categories.length).toEqual(2)
     })
+
+    it('maintains category ids after it is filtered', () => {
+      subject = render({emojisToShowFilter: emoji => true});
+      const categoriesWithIds = subject.categories.filter(category => category.id);
+      expect(categoriesWithIds.length).toEqual(10);
+    });
   })
 })

--- a/src/components/picker.js
+++ b/src/components/picker.js
@@ -108,6 +108,7 @@ export default class Picker extends React.PureComponent {
           let newCategory = {
             emojis: newEmojis,
             name: category.name,
+            id: category.id
           }
 
           this.categories.push(newCategory)


### PR DESCRIPTION
Providing the `emojisToShowFilter` function to the component was causing the following React warning:

> ERROR: 'Warning: Each child in an array or iterator should have a unique "key" prop.
> 
> Check the render method of `Anchors`. See https://fb.me/react-warning-keys for more information.
>     in span (created by Anchors)
>     in Anchors (created by Picker)
>     in div (created by Picker)
>     in div (created by Picker)
>     in Picker'

The cause was that the new category that's created with the filtered results didn't have its `id` value specified (only its `name` and `emojis` attributes).

This PR simply adds the `id` field back into the category. I've added an additional test to check for it as well.

Thanks for this great component!