### PR TITLE
add required props in <Emoji /> example

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ Sheets are served from [unpkg](https://unpkg.com), a global CDN that serves file
 ```jsx
 import { Emoji } from 'emoji-mart'
 
-<Emoji emoji={{ id: 'santa', skin: 3 }} />
-<Emoji emoji=':santa::skin-tone-3:' />
-<Emoji emoji='santa' set='emojione' />
+<Emoji emoji={{ id: 'santa', skin: 3 }} size={16} />
+<Emoji emoji=':santa::skin-tone-3:' size={16} />
+<Emoji emoji='santa' set='emojione' size={16} />
 ```
 
 | Prop | Required | Default | Description |


### PR DESCRIPTION
Without `size` `<Emoji />` doesn't render correctly.