### PR TITLE
Emoji fallback shouldn't apply styling #157

### DIFF
--- a/src/components/emoji.js
+++ b/src/components/emoji.js
@@ -198,7 +198,6 @@ Emoji.defaultProps = {
   onOver: () => {},
   onLeave: () => {},
   onClick: () => {},
-  fallback: emoji => {},
 }
 
 export default Emoji

--- a/src/components/emoji.js
+++ b/src/components/emoji.js
@@ -123,7 +123,7 @@ const Emoji = props => {
 
     if (!setHasEmoji) {
       if (props.fallback) {
-        children = props.fallback(data)
+        return props.fallback(data)
       } else {
         return null
       }

--- a/src/components/emoji.js
+++ b/src/components/emoji.js
@@ -123,7 +123,6 @@ const Emoji = props => {
 
     if (!setHasEmoji) {
       if (props.fallback) {
-        style = { fontSize: props.size }
         children = props.fallback(data)
       } else {
         return null


### PR DESCRIPTION
My use of the fallback mechanism just added is the same as was mentioned in the linked issue.

```
<Emoji
  set={'messenger'}
  emoji={'shrug'}
  size={24}
  fallback={(emoji) => {
    return `:${emoji.short_names[0]}:`
  }}
/>
```

In a case where the fallback is utilised, I'd prefer that styling wasn't applied.

Of course, feel free to close this pull request if there are other reasons that the font-size needs to be maintained!