### PR TITLE
fix Categories sort compareFunction return to -1 from 0 in Picker component

### DIFF
--- a/src/components/picker.js
+++ b/src/components/picker.js
@@ -71,7 +71,7 @@ export default class Picker extends React.PureComponent {
           return 1
         }
 
-        return 0
+        return -1
       })
     }
 


### PR DESCRIPTION
I tried to use Picker component with include props.

```jsx
<Picker
  include={["foods", "nature"]}
  onClick={this._updateEmoji.bind(this)}
  showPreview={false} />
```

But it seems that sort order is different depending on browsers. It is a result by Desktop Chrome ( Mobile device emulator mode ) and Mobile Chrome ( iPhone X ).

Desktop Chrome ( emulator mode ) | Mobile Chrome ( iPhone X )
---|---
v64.0.3282.140 | v64.0.3282.112
return ["foods", "nature"] | return ["nature", "foods"]
<img width="372" alt="2018-02-15 18 58 36" src="https://user-images.githubusercontent.com/2892422/36250820-42bada72-1282-11e8-9e8a-fc8d8d9984f5.png">|<img width="372" alt="2018-02-15 18 58 36" src="https://user-images.githubusercontent.com/2892422/36250836-538a362c-1282-11e8-9fca-2a1dfc46575e.PNG">

I think this document in MDN is related.

[Array.prototype.sort()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) , 

> If compareFunction(a, b) returns 0, leave a and b unchanged with respect to each other, but sorted with respect to all different elements.  Note: the ECMAscript standard does not guarantee this behaviour, and thus not all browsers (e.g. Mozilla versions dating back to at least 2003) respect this.

This PR simply change return of compareFunction to -1 from 0, it seems to be working fine. 

Thanks for this great component!