### PR TITLE
Custom Emojis as a changing prop

### DIFF
--- a/src/components/picker.js
+++ b/src/components/picker.js
@@ -61,6 +61,8 @@ export default class Picker extends React.PureComponent {
       })
 
       allCategories.push(CUSTOM_CATEGORY)
+    } else if (CUSTOM_CATEGORY.emojis.length > 0) {
+      CUSTOM_CATEGORY.emojis = [];
     }
 
     this.hideRecent = true


### PR DESCRIPTION
👋 

**Encountered issue:**
We provide the picker with custom emojis based on different contexts, which means that in certain circumstances, the picker has custom emojis that will not be present at the next opening.
However, the `CUSTOM_CATEGORY` emojis array is built outside of the `Picker` class, and is kept in memory for all uses of the Picker, and therefore keeps any emojis its provided in memory, even when the Picker receives an empty `custom` prop in the future.

**Fix:**
Upon construction of the `Picker`, as we check if the `custom` prop has no length, I check if the `CUSTOM_CATEGORY` object contains emojis with a length, and reset it if so, to avoid contamination.