### PR TITLE
Clearing custom emojis from index and pool when necessary

### DIFF
--- a/src/utils/emoji-index.js
+++ b/src/utils/emoji-index.js
@@ -5,6 +5,7 @@ var originalPool = {}
 var index = {}
 var emojisList = {}
 var emoticonsList = {}
+var customEmojisList = []
 
 for (let emoji in data.emojis) {
   let emojiData = data.emojis[emoji],
@@ -25,7 +26,18 @@ for (let emoji in data.emojis) {
   originalPool[id] = emojiData
 }
 
+function clearCustomEmojis(pool) {
+  customEmojisList.forEach(emoji => {
+    let emojiId = emoji.id || emoji.short_names[0]
+
+    delete pool[emojiId]
+    delete emojisList[emojiId]
+  })
+}
+
 function addCustomToPool(custom, pool) {
+  if (customEmojisList.length) clearCustomEmojis(pool)
+
   custom.forEach(emoji => {
     let emojiId = emoji.id || emoji.short_names[0]
 
@@ -34,13 +46,16 @@ function addCustomToPool(custom, pool) {
       emojisList[emojiId] = getSanitizedData(emoji)
     }
   })
+
+  customEmojisList = custom
+  index = {}
 }
 
 function search(
   value,
   { emojisToShowFilter, maxResults, include, exclude, custom = [] } = {}
 ) {
-  addCustomToPool(custom, originalPool)
+  if (customEmojisList != custom) addCustomToPool(custom, originalPool)
 
   maxResults || (maxResults = 75)
   include || (include = [])


### PR DESCRIPTION
👋 

**Problem & how to reproduce:**
File `emoji-index.js` has four global variables, that will mutate whenever you search an emoji with the search input:
```
var originalPool = {}
var index = {}
var emojisList = {}
var emoticonsList = {}
```
Considering you have Emoji Pickers in different places (different communities), where the custom emojis that are provided to those pickers vary, if the index nor the pool get "contaminated" with the custom emojis of one Picker, every other will contain them in their search results.

**Solution provided**
_The best approach would probably have been to re-factor those four global variables to bind them to the Emoji Picker instead of having them be globally instantiated. However, the `emoji-index.js` util exports emojis and emoticons, therefore in order to avoid any further regression, I approached the issue differently to work on a patch rather than a refactor ~_

Instead of calling `addCustomToPool` at every search call triggered, I store the previously provided custom emojis and store them in a list, that I compare the custom emojis provided along the search with, to define whether we need to feed the pool (and the emojisList) with those. In addition to that, whenever there's a change identified between the previous, and the new custom emojis, I remove the entries of old custom emojis, and clear the indexes, which in the case of a new custom prop provided, is a reliable (and possibly the least expensive) way to clear the indexed results and pools.

I know this is a pretty specific fix for projects that are using emoji pickers in different contexts, sorry about that! 🙏 

*Edit:* I reproduced the faulty behaviour in a sandbox so you can witness it: https://codesandbox.io/s/20wwk5nj0r