### PR TITLE
Correct NimbleEmojiIndex reexport

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,5 +10,5 @@ export {
   Category,
 } from './components'
 
-export { NimbleEmojiIndex } from './utils/emoji-index/nimble-emoji-index'
+export { default as NimbleEmojiIndex } from './utils/emoji-index/nimble-emoji-index'
 export { emojiIndex, store, frequently }


### PR DESCRIPTION
`./utils/emoji-index/nimble-emoji-index` has a default export, not a named export.