### PR TITLE
Added font stack to support native emojis in IE11/Edge

### DIFF
--- a/css/emoji-mart.css
+++ b/css/emoji-mart.css
@@ -138,6 +138,10 @@
   font-size: 0;
 }
 
+.emoji-mart-emoji-native {
+  font-family: "Segoe UI Emoji", "Segoe UI Symbol", "Segoe UI", "Apple Color Emoji";
+}
+
 .emoji-mart-no-results {
   font-size: 14px;
   text-align: center;

--- a/docs/emoji-mart.css
+++ b/docs/emoji-mart.css
@@ -138,6 +138,10 @@
   font-size: 0;
 }
 
+.emoji-mart-emoji-native {
+  font-family: "Segoe UI Emoji", "Segoe UI Symbol", "Segoe UI", "Apple Color Emoji";
+}
+
 .emoji-mart-no-results {
   font-size: 14px;
   text-align: center;


### PR DESCRIPTION
Hi! This adds support for native emojis in IE11, previously rendered as black & white icons. Adjusting the font stack will also enable full support on Edge too, some emojis are broken too.

IE11 on Windows 10 using native emoji:

![ie11-before](https://user-images.githubusercontent.com/160260/42534171-4b10cfd4-848c-11e8-99a6-278c4d4146d2.png)

Same platform, but after applying the change, it should render native emojis properly:

![ie11-after](https://user-images.githubusercontent.com/160260/42534192-5c9e2e90-848c-11e8-82fb-9f3ca6b03027.png)

I didn't test in in previous windows versions, I suspect it won't work if font is not available.

Emoji-mart is awesome, saved us a lot of time - thanks for contributing it to the world!



