### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Sheets are served from [unpkg](https://unpkg.com), a global CDN that serves file
 | emojione  | 315 KB                 | 435 KB                 | 1020 KB                | 2.33 MB                |
 | facebook  | 322 KB                 | 439 KB                 | 1020 KB                | 2.50 MB                |
 | google    | 301 KB                 | 409 KB                 |  907 KB                | 2.17 MB                |
-| messenger | 325 KB                 | 449 MB                 | 1.05 MB                | 2.69 MB                |
+| messenger | 325 KB                 | 449 KB                 | 1.05 MB                | 2.69 MB                |
 | twitter   | 288 KB                 | 389 KB                 |  839 KB                | 1.82 MB                |
 
 #### Datasets


### PR DESCRIPTION
The sheet size for messenger says that the emoji download size is 449
_megabytes_ for a sheetSize of 32.
449 _kilobytes_ is the correct value.