### PR TITLE
Fixes display of non-52x52 sprite sheets in the preview bar

### DIFF
--- a/src/components/picker/nimble-picker.js
+++ b/src/components/picker/nimble-picker.js
@@ -571,6 +571,8 @@ export default class NimblePicker extends React.PureComponent {
                 skin: skin,
                 set: set,
                 sheetSize: sheetSize,
+                sheetColumns: sheetColumns,
+                sheetRows: sheetRows,
                 backgroundImageFn: backgroundImageFn,
               }}
               skinsProps={{


### PR DESCRIPTION
In fixing #211, I neglected to also ensure that non-square (52x52) sprite sheets also work in the preview bar. This PR corrects that oversight.