### PR TITLE
Import compoments directly to avoid components/picker/index.js and have smaller bundle

### DIFF
--- a/src/components/category.js
+++ b/src/components/category.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types'
 
 import frequently from '../utils/frequently'
 import { getData } from '../utils'
-import { NimbleEmoji, NotFound } from '.'
+import NimbleEmoji from './emoji/nimble-emoji'
+import NotFound from './not-found'
 
 export default class Category extends React.Component {
   constructor(props) {

--- a/src/components/picker/nimble-picker.js
+++ b/src/components/picker/nimble-picker.js
@@ -10,7 +10,10 @@ import { deepMerge, measureScrollbar } from '../../utils'
 import { uncompress } from '../../utils/data'
 import { PickerPropTypes, PickerDefaultProps } from '../../utils/shared-props'
 
-import { Anchors, Category, Preview, Search } from '..'
+import Anchors from '../anchors'
+import Category from '../category'
+import Preview from '../preview'
+import Search from '../search'
 
 const I18N = {
   search: 'Search',

--- a/src/components/preview.js
+++ b/src/components/preview.js
@@ -2,7 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { getData } from '../utils'
-import { NimbleEmoji, SkinsEmoji, SkinsDot } from '.'
+import NimbleEmoji from './emoji/nimble-emoji'
+import SkinsEmoji from './skins-emoji'
+import SkinsDot from './skins-dot'
 
 export default class Preview extends React.PureComponent {
   constructor(props) {


### PR DESCRIPTION
Those simple changes would allow importing Nimbleicker directly and avoid having all.json bundled when using apple.json or other emoji collections.
