### PR TITLE
fix: fix native emoji on Linux

### DIFF
--- a/css/emoji-mart.css
+++ b/css/emoji-mart.css
@@ -153,7 +153,7 @@
 }
 
 .emoji-mart-emoji-native {
-  font-family: "Segoe UI Emoji", "Segoe UI Symbol", "Segoe UI", "Apple Color Emoji";
+  font-family: "Segoe UI Emoji", "Segoe UI Symbol", "Segoe UI", "Apple Color Emoji", "Twemoji Mozilla", "Noto Color Emoji", "EmojiOne Color", "Android Emoji";
 }
 
 .emoji-mart-no-results {


### PR DESCRIPTION
fixes #255 

On Ubuntu, Firefox uses a built-in Twemoji font, whereas other browsers like Chrome and GNOME Web (aka Epiphany Browser) use the built-in-to-the-OS EmojiOne font. This change respects the Firefox style while also fixing the GNOME Web style.

GNOME Web before:

![screenshot from 2018-12-18 10-12-09](https://user-images.githubusercontent.com/283842/50174009-dce36a80-02ad-11e9-989d-99c98b57299e.png)

GNOME Web after:

![screenshot from 2018-12-18 10-11-27](https://user-images.githubusercontent.com/283842/50174016-e10f8800-02ad-11e9-9343-7ac836203fba.png)

"Android Emoji" is for older version of Android before Noto Color was built-in.