### PR TITLE
fix: forces emoji's not to break line

### DIFF
--- a/src/components/emoji/nimble-emoji.js
+++ b/src/components/emoji/nimble-emoji.js
@@ -120,6 +120,7 @@ const NimbleEmoji = (props) => {
       style.display = 'inline-block'
       style.width = props.size
       style.height = props.size
+      style.wordBreak = 'keep-all'
     }
   } else if (custom) {
     className += ' emoji-mart-emoji-custom'


### PR DESCRIPTION
closes issue [#252 ](https://github.com/missive/emoji-mart/issues/252)

On Firefox and Safari, emojis were larger than their 24px container and were splitting into multiple rows causing formatting issues. Adding this css rule will force the emoji's to not break.