### PR TITLE
fix: fix preact compat

### DIFF
--- a/src/components/category.js
+++ b/src/components/category.js
@@ -16,8 +16,6 @@ export default class Category extends React.Component {
   }
 
   componentDidMount() {
-    this.parent = this.container.parentNode
-
     this.margin = 0
     this.minMargin = 0
 
@@ -67,10 +65,10 @@ export default class Category extends React.Component {
 
   memoizeSize() {
     var { top, height } = this.container.getBoundingClientRect()
-    var { top: parentTop } = this.parent.getBoundingClientRect()
+    var { top: parentTop } = this.container.parentNode.getBoundingClientRect()
     var { height: labelHeight } = this.label.getBoundingClientRect()
 
-    this.top = top - parentTop + this.parent.scrollTop
+    this.top = top - parentTop + this.container.parentNode.scrollTop
 
     if (height == 0) {
       this.maxMargin = 0


### PR DESCRIPTION
fixes #254

I'm not sure why Preact is subtly different from React, but not caching `this.parent` fixes the error. I don't think there's any performance hit for _not_ caching it (`container.parentElement` should be a cheap operation), so it seems worth it to get compatibility with Preact.

You can test this by using [this branch](https://github.com/nolanlawson/emoji-mart/tree/fix-preact-compat-test) and running the storybook. Before this fix, there's an error in the console; after this fix, there isn't.