### PR TITLE
Fixed bug where selecting the first emoji search result with the ENTER KEY ignores skin tone selection

### DIFF
--- a/src/components/picker/nimble-picker.js
+++ b/src/components/picker/nimble-picker.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 import * as icons from '../../svgs'
 import store from '../../utils/store'
 import frequently from '../../utils/frequently'
-import { deepMerge, measureScrollbar } from '../../utils'
+import { deepMerge, measureScrollbar, getSanitizedData } from '../../utils'
 import { uncompress } from '../../utils/data'
 import { PickerPropTypes, PickerDefaultProps } from '../../utils/shared-props'
 
@@ -396,7 +396,12 @@ export default class NimblePicker extends React.PureComponent {
 
         if (
           this.SEARCH_CATEGORY.emojis &&
-          (emoji = this.SEARCH_CATEGORY.emojis[0])
+          (emoji = getSanitizedData(
+            this.SEARCH_CATEGORY.emojis[0],
+            this.state.skin,
+            this.props.set,
+            this.props.data,
+          ))
         ) {
           this.handleEmojiSelect(emoji)
         }


### PR DESCRIPTION
Fixed bug where selecting the first emoji search result with the ENTER key ignores skin-tone selection. This bug was due to the fact that the emojis in a `Category` are rendered as `NimbleEmoji`, where skin-tone data and other properties are populated via `getSanitizedData` (this data is not present in the `Category`'s emoji). Clicking an emoji therefore worked as expected since the click triggered the `NimbleEmoji`'s `handleClick` function which called `getSanitizedData`. Pressing the enter key, however, triggered the `NimblePicker`'s `handleKeyDown` function which simply returned the first emoji in `SEARCH_CATEGORY` (thus lacking the skin-tone data). Imported `getSanitizedData` from `utils` and called it in `handleKeyDown` to resolve the issue. Please let me know if you would like any more information or if changes are required to match coding style. 