### PR TITLE
Add support for passing a custom class name to all components

### DIFF
--- a/src/components/category.js
+++ b/src/components/category.js
@@ -153,6 +153,7 @@ export default class Category extends React.Component {
         i18n,
         notFound,
         notFoundEmoji,
+        className,
       } = this.props,
       emojis = this.getEmojis(),
       labelStyles = {},
@@ -178,7 +179,7 @@ export default class Category extends React.Component {
     return (
       <div
         ref={this.setContainerRef}
-        className="emoji-mart-category"
+        className={`emoji-mart-category ${className ? ' ' + className : ''}`}
         style={containerStyles}
       >
         <div
@@ -221,6 +222,7 @@ Category.propTypes = {
   recent: PropTypes.arrayOf(PropTypes.string),
   notFound: PropTypes.func,
   notFoundEmoji: PropTypes.string.isRequired,
+  className: PropTypes.string,
 }
 
 Category.defaultProps = {

--- a/src/components/emoji/nimble-emoji.js
+++ b/src/components/emoji/nimble-emoji.js
@@ -99,6 +99,10 @@ const NimbleEmoji = (props) => {
     className = 'emoji-mart-emoji',
     title = null
 
+  if (props.className) {
+    className += ' ' + className
+  }
+
   if (!unified && !custom) {
     if (props.fallback) {
       return props.fallback(data, props)

--- a/src/components/picker/nimble-picker.js
+++ b/src/components/picker/nimble-picker.js
@@ -454,7 +454,7 @@ export default class NimblePicker extends React.PureComponent {
   }
 
   render() {
-    var {
+    const {
         perLine,
         emojiSize,
         set,
@@ -478,6 +478,8 @@ export default class NimblePicker extends React.PureComponent {
         skinEmoji,
         notFound,
         notFoundEmoji,
+        emojiClassName,
+        className
       } = this.props,
       { skin } = this.state,
       width = perLine * (emojiSize + 12) + 12 + 2 + measureScrollbar()
@@ -485,7 +487,7 @@ export default class NimblePicker extends React.PureComponent {
     return (
       <div
         style={{ width: width, ...style }}
-        className="emoji-mart"
+        className={`emoji-mart ${className ? ' ' + className : ''}`}
         onKeyDown={this.handleKeyDown}
       >
         <div className="emoji-mart-bar">
@@ -552,6 +554,7 @@ export default class NimblePicker extends React.PureComponent {
                   onOver: this.handleEmojiOver,
                   onLeave: this.handleEmojiLeave,
                   onClick: this.handleEmojiClick,
+                  className: emojiClassName,
                 }}
                 notFound={notFound}
                 notFoundEmoji={notFoundEmoji}
@@ -577,6 +580,7 @@ export default class NimblePicker extends React.PureComponent {
                 sheetColumns: sheetColumns,
                 sheetRows: sheetRows,
                 backgroundImageFn: backgroundImageFn,
+                className: emojiClassName,
               }}
               skinsProps={{
                 skin: skin,

--- a/src/utils/shared-props.js
+++ b/src/utils/shared-props.js
@@ -24,6 +24,7 @@ const EmojiPropTypes = {
   ]),
   size: PropTypes.number.isRequired,
   emoji: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
+  className: PropTypes.string,
 }
 
 const EmojiDefaultProps = {
@@ -37,9 +38,6 @@ const EmojiDefaultProps = {
   tooltip: false,
   backgroundImageFn: (set, sheetSize) =>
     `https://unpkg.com/emoji-datasource-${set}@${EMOJI_DATASOURCE_VERSION}/img/${set}/sheets-256/${sheetSize}.png`,
-  onOver: () => {},
-  onLeave: () => {},
-  onClick: () => {},
 }
 
 const PickerPropTypes = {
@@ -79,12 +77,11 @@ const PickerPropTypes = {
   notFound: PropTypes.func,
   notFoundEmoji: PropTypes.string,
   icons: PropTypes.object,
+  className: PropTypes.string,
+  emojiClassName: PropTypes.string,
 }
 
 const PickerDefaultProps = {
-  onClick: () => {},
-  onSelect: () => {},
-  onSkinChange: () => {},
   emojiSize: 24,
   perLine: 9,
   i18n: {},
@@ -105,7 +102,6 @@ const PickerDefaultProps = {
   autoFocus: false,
   custom: [],
   skinEmoji: '',
-  notFound: () => {},
   notFoundEmoji: 'sleuth_or_spy',
   icons: {},
 }


### PR DESCRIPTION
This adds support for passing a `className` prop to all of the exposed components.

Fixes: #210 