### PR TITLE
Support case where showPreview is false but showSkinTones is true. Also add prepare script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "prepublishOnly": "npm run build",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "prettier": "prettier --write \"{src,scripts,spec}/**/*.js\""
+    "prettier": "prettier --write \"{src,scripts,spec}/**/*.js\"",
+    "prepare": "npm run build:dist"
   },
   "size-limit": [
     {

--- a/src/components/picker/nimble-picker.js
+++ b/src/components/picker/nimble-picker.js
@@ -560,7 +560,7 @@ export default class NimblePicker extends React.PureComponent {
           })}
         </div>
 
-        {showPreview && (
+        {(showPreview || showSkinTones) && (
           <div className="emoji-mart-bar">
             <Preview
               ref={this.setPreviewRef}
@@ -568,6 +568,7 @@ export default class NimblePicker extends React.PureComponent {
               title={title}
               emoji={emoji}
               showSkinTones={showSkinTones}
+              showPreview={showPreview}
               emojiProps={{
                 native: native,
                 size: 38,

--- a/src/components/preview.js
+++ b/src/components/preview.js
@@ -23,9 +23,10 @@ export default class Preview extends React.PureComponent {
         title,
         emoji: idleEmoji,
         i18n,
+        showPreview,
       } = this.props
 
-    if (emoji) {
+    if (emoji && showPreview) {
       var emojiData = getData(emoji, null, null, this.data),
         { emoticons = [] } = emojiData,
         knownEmoticons = [],


### PR DESCRIPTION
It is useful to be able to disable the mouseover emoji preview area but still have showSkinTones available. In particular, in order to be able to use the component on iOS without having to double-click every time it is necessary to disable much mouseover behavior such as this. (see https://css-tricks.com/annoying-mobile-double-tap-link-issue/)

Also, it is useful to have a "prepare" script in the package.json so that it is possible to clone emoji-mart directly from a git repo without extra steps.