### PR TITLE
fix: add prop-types to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "url": "https://github.com/missive/emoji-mart/issues"
   },
   "homepage": "https://github.com/missive/emoji-mart",
-  "dependencies": {},
+  "dependencies": {
+    "prop-types": "^15.6.0"
+  },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-0 || ^16.0.0"
   },
@@ -51,7 +53,6 @@
     "karma-webpack": "^2.0.4",
     "mkdirp": "0.5.1",
     "prettier": "1.11.1",
-    "prop-types": "^15.6.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "rimraf": "2.5.2",


### PR DESCRIPTION
It's probably a rude awakening for some people when they use `emoji-mart` and it complains that `prop-types` are missing. I checked our build output, and the only third-party libraries we require are `react` and `prop-types`, but `react` is already specified as a `peerDependency`.

I looked to see how other React component libraries do it, and it seems [react-virtualized uses a dependency, not a peerDependency, for prop-types](https://unpkg.com/react-virtualized@9.21.0/package.json). So it seems reasonable for us to do the same.