### PR TITLE
fix: improve search/clear a11y

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ import { Picker } from 'emoji-mart'
 #### I18n
 ```js
 search: 'Search',
+clear: 'Clear', // Accessible label on "clear" button
 notfound: 'No Emoji Found',
 skintext: 'Choose your default skin tone',
 categories: {

--- a/css/emoji-mart.css
+++ b/css/emoji-mart.css
@@ -100,14 +100,15 @@
   border-radius: 5px;
   border: 1px solid #d9d9d9;
   outline: 0;
+  -webkit-appearance: none;
 }
 
 .emoji-mart-search-icon {
   position: absolute;
-  top: 9px;
-  right: 16px;
+  top: 7px;
+  right: 11px;
   z-index: 2;
-  padding: 0;
+  padding: 2px 5px 1px;
   border: none;
   background: none;
 }
@@ -369,3 +370,17 @@
 .emoji-mart-skin-tone-4 { background-color: #bf8f68 }
 .emoji-mart-skin-tone-5 { background-color: #9b643d }
 .emoji-mart-skin-tone-6 { background-color: #594539 }
+
+/* For screenreaders only, via https://stackoverflow.com/a/19758620 */
+.emoji-mart-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+

--- a/css/emoji-mart.css
+++ b/css/emoji-mart.css
@@ -102,6 +102,7 @@
   outline: 0;
 }
 
+.emoji-mart-search input,
 .emoji-mart-search input::-webkit-search-decoration,
 .emoji-mart-search input::-webkit-search-cancel-button,
 .emoji-mart-search input::-webkit-search-results-button,

--- a/css/emoji-mart.css
+++ b/css/emoji-mart.css
@@ -100,6 +100,14 @@
   border-radius: 5px;
   border: 1px solid #d9d9d9;
   outline: 0;
+}
+
+.emoji-mart-search input::-webkit-search-decoration,
+.emoji-mart-search input::-webkit-search-cancel-button,
+.emoji-mart-search input::-webkit-search-results-button,
+.emoji-mart-search input::-webkit-search-results-decoration {
+  /* remove webkit/blink styles for <input type="search">
+   * via https://stackoverflow.com/a/9422689 */
   -webkit-appearance: none;
 }
 

--- a/src/components/picker/nimble-picker.js
+++ b/src/components/picker/nimble-picker.js
@@ -18,6 +18,7 @@ import { PickerDefaultProps } from '../../utils/shared-default-props'
 
 const I18N = {
   search: 'Search',
+  clear: 'Clear', // Accessible label on "clear" button
   notfound: 'No Emoji Found',
   skintext: 'Choose your default skin tone',
   categories: {

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -4,12 +4,15 @@ import PropTypes from 'prop-types'
 import { search as icons } from '../svgs'
 import NimbleEmojiIndex from '../utils/emoji-index/nimble-emoji-index'
 
+let id = 0
+
 export default class Search extends React.PureComponent {
   constructor(props) {
     super(props)
     this.state = {
       icon: icons.search,
       isSearching: false,
+      id: ++id
     }
 
     this.data = props.data
@@ -59,28 +62,46 @@ export default class Search extends React.PureComponent {
     }
   }
 
+  clearIfNotSearching () {
+    const { isSearching } = this.state
+    if (!isSearching) {
+      this.clear()
+    }
+  }
+
   setRef(c) {
     this.input = c
   }
 
   render() {
-    var { i18n, autoFocus } = this.props
-    var { icon, isSearching } = this.state
+    const { i18n, autoFocus } = this.props
+    const { icon, id } = this.state
+
+    let inputId = `emoji-mart-search-${id}`
 
     return (
       <div className="emoji-mart-search">
         <input
+          id={inputId}
           ref={this.setRef}
-          type="text"
+          type="search"
           onChange={this.handleChange}
           placeholder={i18n.search}
           autoFocus={autoFocus}
         />
+        {/*
+          * Use a <label> in addition to the placeholder for accessibility, but place it off-screen
+          * http://www.maxability.co.in/2016/01/placeholder-attribute-and-why-it-is-not-accessible/
+          */}
+        <label
+          className="emoji-mart-sr-only"
+          htmlFor={inputId}
+        >{i18n.search}</label>
         <button
           className="emoji-mart-search-icon"
-          onClick={this.clear}
+          onClick={this.clearIfNotSearching}
           onKeyUp={this.handleKeyUp}
-          disabled={!isSearching}
+          aria-label={i18n.clear}
         >
           {icon()}
         </button>

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -49,6 +49,7 @@ export default class Search extends React.PureComponent {
   clear() {
     if (this.input.value == '') return
     this.input.value = ''
+    this.input.focus()
     this.search('')
   }
 
@@ -62,20 +63,13 @@ export default class Search extends React.PureComponent {
     }
   }
 
-  clearIfNotSearching() {
-    const { isSearching } = this.state
-    if (!isSearching) {
-      this.clear()
-    }
-  }
-
   setRef(c) {
     this.input = c
   }
 
   render() {
     const { i18n, autoFocus } = this.props
-    const { icon, id } = this.state
+    const { icon, isSearching, id } = this.state
     const inputId = `emoji-mart-search-${id}`
 
     return (
@@ -97,9 +91,10 @@ export default class Search extends React.PureComponent {
         </label>
         <button
           className="emoji-mart-search-icon"
-          onClick={this.clearIfNotSearching}
+          onClick={this.clear}
           onKeyUp={this.handleKeyUp}
           aria-label={i18n.clear}
+          disabled={!isSearching}
         >
           {icon()}
         </button>

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -76,8 +76,7 @@ export default class Search extends React.PureComponent {
   render() {
     const { i18n, autoFocus } = this.props
     const { icon, id } = this.state
-
-    let inputId = `emoji-mart-search-${id}`
+    const inputId = `emoji-mart-search-${id}`
 
     return (
       <div className="emoji-mart-search">

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -12,7 +12,7 @@ export default class Search extends React.PureComponent {
     this.state = {
       icon: icons.search,
       isSearching: false,
-      id: ++id
+      id: ++id,
     }
 
     this.data = props.data
@@ -62,7 +62,7 @@ export default class Search extends React.PureComponent {
     }
   }
 
-  clearIfNotSearching () {
+  clearIfNotSearching() {
     const { isSearching } = this.state
     if (!isSearching) {
       this.clear()
@@ -92,10 +92,9 @@ export default class Search extends React.PureComponent {
           * Use a <label> in addition to the placeholder for accessibility, but place it off-screen
           * http://www.maxability.co.in/2016/01/placeholder-attribute-and-why-it-is-not-accessible/
           */}
-        <label
-          className="emoji-mart-sr-only"
-          htmlFor={inputId}
-        >{i18n.search}</label>
+        <label className="emoji-mart-sr-only" htmlFor={inputId}>
+          {i18n.search}
+        </label>
         <button
           className="emoji-mart-search-icon"
           onClick={this.clearIfNotSearching}


### PR DESCRIPTION
Fixes the issues described in #221:

1. Adds a new `i18n.clear` value (default of "Clear") as the accessible label for the clear button
2. ~~To give the clear button a focus style, avoid making it disabled when the search is focused. Otherwise when you press <kbd>tab</kbd>, it doesn't change focus to the clear button. (Rather than disabling it, I made it so that if you somehow click the button while searching, it just does nothing.)~~ _ignore, I was wrong about this_
3. Tweak the styles on the clear button to give it more padding, so that the outline appears nicer-looking. As an added bonus, this improves the touch target size for the button, although for the best a11y, [it really should be at least 44x44 pixels](https://a11yproject.com/posts/large-touch-targets/) (right now it's 23x19).

Visually the button should look exactly the same when not focused. When it is focused, it will use the user agent default stylesheet (in my case, Ubuntu orange):

![out](https://user-images.githubusercontent.com/283842/54077414-9da13600-426c-11e9-888a-92a00cc7a6b3.png)

I also made some other a11y fixes in the same part of the code:

1. Adds a `<label>` to the `<input>` because [a placeholder is not enough for a11y](http://www.maxability.co.in/2016/01/placeholder-attribute-and-why-it-is-not-accessible/).
2. Change `<input type="text">` to `<input type="search">`, because that's what it is. :slightly_smiling_face: To fix issues with user agent styles adding their own "search" style, I added `-webkit-appearance: none;`.