### PR TITLE
fix: make categories into accessible nav buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ import { Picker } from 'emoji-mart'
 search: 'Search',
 notfound: 'No Emoji Found',
 skintext: 'Choose your default skin tone',
+categorieslabel: 'Emoji categories', // Accessible title for the list of categories
 categories: {
   search: 'Search Results',
   recent: 'Frequently Used',

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ import { Picker } from 'emoji-mart'
 search: 'Search',
 notfound: 'No Emoji Found',
 skintext: 'Choose your default skin tone',
-categorieslabel: 'Emoji categories', // Accessible title for the list of categories
 categories: {
   search: 'Search Results',
   recent: 'Frequently Used',
@@ -73,7 +72,8 @@ categories: {
   symbols: 'Symbols',
   flags: 'Flags',
   custom: 'Custom',
-}
+},
+categorieslabel: 'Emoji categories', // Accessible title for the list of categories
 ```
 
 #### Sheet sizes

--- a/css/emoji-mart.css
+++ b/css/emoji-mart.css
@@ -49,6 +49,10 @@
   padding: 12px 4px;
   overflow: hidden;
   transition: color .1s ease-out;
+  margin: 0;
+  box-shadow: none;
+  background: none;
+  border: none;
 }
 .emoji-mart-anchor:hover,
 .emoji-mart-anchor-selected {

--- a/css/emoji-mart.css
+++ b/css/emoji-mart.css
@@ -78,7 +78,7 @@
 
 .emoji-mart-anchors svg,
 .emoji-mart-anchors img {
-  fill: currentColor;
+  fill: #858585;
   height: 18px;
   width: 18px;
 }

--- a/src/components/anchors.js
+++ b/src/components/anchors.js
@@ -28,7 +28,7 @@ export default class Anchors extends React.PureComponent {
       { selected } = this.state
 
     return (
-      <div className="emoji-mart-anchors">
+      <nav className="emoji-mart-anchors" aria-label={i18n.categorieslabel}>
         {categories.map((category, i) => {
           var { id, name, anchor } = category,
             isSelected = name == selected
@@ -38,8 +38,9 @@ export default class Anchors extends React.PureComponent {
           }
 
           return (
-            <span
+            <button
               key={id}
+              aria-label={i18n.categories[id]}
               title={i18n.categories[id]}
               data-index={i}
               onClick={this.handleClick}
@@ -55,10 +56,10 @@ export default class Anchors extends React.PureComponent {
                 className="emoji-mart-anchor-bar"
                 style={{ backgroundColor: color }}
               />
-            </span>
+            </button>
           )
         })}
-      </div>
+      </nav>
     )
   }
 }

--- a/src/components/picker/nimble-picker.js
+++ b/src/components/picker/nimble-picker.js
@@ -20,6 +20,7 @@ const I18N = {
   search: 'Search',
   notfound: 'No Emoji Found',
   skintext: 'Choose your default skin tone',
+  categorieslabel: 'Emoji categories',
   categories: {
     search: 'Search Results',
     recent: 'Frequently Used',

--- a/src/components/picker/nimble-picker.js
+++ b/src/components/picker/nimble-picker.js
@@ -20,7 +20,6 @@ const I18N = {
   search: 'Search',
   notfound: 'No Emoji Found',
   skintext: 'Choose your default skin tone',
-  categorieslabel: 'Emoji categories',
   categories: {
     search: 'Search Results',
     recent: 'Frequently Used',
@@ -34,6 +33,7 @@ const I18N = {
     flags: 'Flags',
     custom: 'Custom',
   },
+  categorieslabel: 'Emoji categories', // Accessible title for the list of categories
 }
 
 export default class NimblePicker extends React.PureComponent {


### PR DESCRIPTION
fixes #219

1. Changes the categories `<div>` into a `<nav>` (see [navigation role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Navigation_Role) for details).
2. Changes each category button into a true `<button>`. This makes it tabbable, and you can press the <kbd>space</kbd> button to press them.
3. Adds `aria-label` for each button, since the `title` is not sufficient for a11y
4. Adds an `aria-label` to the `<nav>` to help distinguish it from any other `<nav>`s that may be on the page. This requires a new `i18n` label ("Emoji categories" by default).

Here is a GIF of me pressing <kbd>tab</kbd> and <kbd>spacebar</kbd> to demonstrate: https://gfycat.com/agedwindycockatiel