### PR TITLE
fix: makes skin tone picker more accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ categories: {
   custom: 'Custom',
 },
 categorieslabel: 'Emoji categories', // Accessible title for the list of categories
+skintones: {
+  1: 'Default Skin Tone',
+  2: 'Light Skin Tone',
+  3: 'Medium-Light Skin Tone',
+  4: 'Medium Skin Tone',
+  5: 'Medium-Dark Skin Tone',
+  6: 'Dark Skin Tone',
+},
 ```
 
 #### Sheet sizes

--- a/src/components/picker/nimble-picker.js
+++ b/src/components/picker/nimble-picker.js
@@ -35,6 +35,14 @@ const I18N = {
     custom: 'Custom',
   },
   categorieslabel: 'Emoji categories', // Accessible title for the list of categories
+  skintones: {
+    1: 'Default Skin Tone',
+    2: 'Light Skin Tone',
+    3: 'Medium-Light Skin Tone',
+    4: 'Medium Skin Tone',
+    5: 'Medium-Dark Skin Tone',
+    6: 'Dark Skin Tone',
+  },
 }
 
 export default class NimblePicker extends React.PureComponent {

--- a/src/components/skins-dot.js
+++ b/src/components/skins-dot.js
@@ -8,6 +8,14 @@ export default class SkinsDot extends Skins {
     super(props)
 
     this.handleClick = this.handleClick.bind(this)
+    this.handleKeyDown = this.handleKeyDown.bind(this)
+  }
+
+  handleKeyDown(event) {
+    // if either enter or space is pressed, then execute
+    if (event.keyCode === 13 || event.keyCode === 32) {
+      this.handleClick(event)
+    }
   }
 
   render() {
@@ -17,6 +25,7 @@ export default class SkinsDot extends Skins {
 
     for (let skinTone = 1; skinTone <= 6; skinTone++) {
       const selected = skinTone === skin
+      const visible = opened || selected
       skinToneNodes.push(
         <span
           key={`skin-tone-${skinTone}`}
@@ -24,6 +33,15 @@ export default class SkinsDot extends Skins {
         >
           <span
             onClick={this.handleClick}
+            onKeyDown={this.handleKeyDown}
+            role="button"
+            tabindex={visible ? '0' : ''}
+            aria-hidden={!visible}
+            aria-pressed={opened ? !!selected : ''}
+            aria-haspopup={!!selected}
+            aria-expanded={selected ? opened : ''}
+            aria-label={i18n.skintones[skinTone]}
+            title={i18n.skintones[skinTone]}
             data-skin={skinTone}
             className={`emoji-mart-skin emoji-mart-skin-tone-${skinTone}`}
           />
@@ -32,9 +50,12 @@ export default class SkinsDot extends Skins {
     }
 
     return (
-      <div className={`emoji-mart-skin-swatches${opened ? ' opened' : ''}`}>
+      <section
+        className={`emoji-mart-skin-swatches${opened ? ' opened' : ''}`}
+        aria-label={i18n.skintext}
+      >
         {skinToneNodes}
-      </div>
+      </section>
     )
   }
 }


### PR DESCRIPTION
fixes #220

I still think this solution leaves a lot to be desired, but this is the best I could do for now while maintaining the existing design. I believe we should probably separate out the button that expands the menu and the buttons inside the menu, but this is a start.

1. I made all `<span>`s into `role="button"`. (It was too difficult to make them true `<button>`s, but I would love a PR in the future to do that. ) :slightly_smiling_face: Because they aren't true buttons, we have to handle `tabindex` and keydown (enter/spacebar) ourselves.
2. I added `aria-haspopup` and `aria-expanded` to indicate when the menu button is opened.
3. I added a `<section>` with `aria-label` set to the `i18n.skintext` (default: 'Choose your default skin tone') so that it's easier to tell what this mass of `<button>`s is there for
4. I added `aria-pressed` states for when the skintone is selected/unselected to show that it's a toggle button
5. I added some text for each skintone button, via both `aria-label` and `title` so that you can hover to see them. This necessitated some new `i18n` defaults.

This is definitely not where I would like it to be long-term, but at the very least you can now tab to the button, press spacebar/enter to expand, and then tab through the expanded buttons and press spacebar/enter to expand those.