### PR TITLE
perf: cache the scrollbar width

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -171,8 +171,13 @@ function deepMerge(a, b) {
   return o
 }
 
+let scrollbarWidth
+
 // https://github.com/sonicdoe/measure-scrollbar
 function measureScrollbar() {
+  if (typeof scrollbarWidth === 'number') {
+    return scrollbarWidth
+  }
   if (typeof document == 'undefined') return 0
   const div = document.createElement('div')
 
@@ -183,7 +188,7 @@ function measureScrollbar() {
   div.style.top = '-9999px'
 
   document.body.appendChild(div)
-  const scrollbarWidth = div.offsetWidth - div.clientWidth
+  scrollbarWidth = div.offsetWidth - div.clientWidth
   document.body.removeChild(div)
 
   return scrollbarWidth


### PR DESCRIPTION
When loading the storybook, `measureScrollbar()` is called 15 times. Each time, we insert and remove elements from the DOM, and invoke style/layout. This seems wasteful, since the width of a scrollbar is unlikely to change during the lifecycle of the page. We should be able to just measure it once and cache the measured value.