### PR TITLE
fix: remove unused notFoundString prop

### DIFF
--- a/src/components/not-found.js
+++ b/src/components/not-found.js
@@ -28,6 +28,5 @@ export default class NotFound extends React.PureComponent {
 
 NotFound.propTypes /* remove-proptypes */ = {
   notFound: PropTypes.func.isRequired,
-  notFoundString: PropTypes.string.isRequired,
   emojiProps: PropTypes.object.isRequired,
 }


### PR DESCRIPTION
While playing with the storybook, I noticed a warning:

```
Warning: Failed prop type: The prop `notFoundString` is marked as required in `NotFound`, but its value is `undefined`.
    in NotFound (created by Category)
    in Category (created by NimblePicker)
    in div (created by NimblePicker)
    in div (created by NimblePicker)
    in NimblePicker (created by Picker)
    in Picker
    in WrapStory
```

This prop seems to be entirely unused, since this component actually uses `i18n.notfound` instead. I also can't find any documentation or any other references to it. It seems safe to remove.