### PR TITLE
fix: fix emoji.id undefined error

### DIFF
--- a/src/components/picker/nimble-picker.js
+++ b/src/components/picker/nimble-picker.js
@@ -397,6 +397,7 @@ export default class NimblePicker extends React.PureComponent {
 
         if (
           this.SEARCH_CATEGORY.emojis &&
+          this.SEARCH_CATEGORY.emojis.length &&
           (emoji = getSanitizedData(
             this.SEARCH_CATEGORY.emojis[0],
             this.state.skin,


### PR DESCRIPTION
fixes #201 

Steps to reproduce:

1. Open the storybook
2. Type some text that results in "not found"
3. Press enter
4. Check the dev console for the error

The error is:

```
Uncaught TypeError: Cannot read property 'id' of undefined
    at getData (index.js:99)
    at getSanitizedData (index.js:73)
    at NimblePicker.handleKeyDown (nimble-picker.js:476)
    at HTMLUnknownElement.callCallback (react-dom.development.js:1299)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:1338)
    at Object.invokeGuardedCallback (react-dom.development.js:1195)
    at Object.invokeGuardedCallbackAndCatchFirstError (react-dom.development.js:1209)
    at executeDispatch (react-dom.development.js:1432)
    at Object.executeDispatchesInOrder (react-dom.development.js:1454)
    at executeDispatchesAndRelease (react-dom.development.js:1969)
```

This happens when the search list is empty. Checking the `.length` of the list fixes it.