### PR TITLE
fix: fix search input when value is prepopulated

### DIFF
--- a/src/components/search.js
+++ b/src/components/search.js
@@ -26,6 +26,13 @@ export default class Search extends React.PureComponent {
     this.handleChange = throttleIdleTask(this.handleChange.bind(this))
   }
 
+  componentDidMount() {
+    // in some cases (e.g. preact) the input may already be pre-populated
+    if (this.input.value) {
+      this.search(this.input.value)
+    }
+  }
+
   search(value) {
     if (value == '')
       this.setState({


### PR DESCRIPTION
In some cases (notably with Preact it seems), the `<input type="search">` value may be prepopulated (due to cached DOM nodes being re-hydrated, I suppose). In those cases, you can cause a bug if you do e.g.:

1. Type "horse" into the search
2. Press enter to choose the :horse: emoji
3. Reopen the picker (can't be reproduced in the storybook, but can be reproduced in [Pinafore](http://github.com/nolanlawson/pinafore/))
4. The search input is prepopulated, but the search results are empty

This fixes that, by performing a search if the input happens to contain any text.