### PR TITLE
fix: use tabIndex, not tabindex

### DIFF
--- a/src/components/skins-dot.js
+++ b/src/components/skins-dot.js
@@ -35,7 +35,7 @@ export default class SkinsDot extends Skins {
             onClick={this.handleClick}
             onKeyDown={this.handleKeyDown}
             role="button"
-            tabindex={visible ? '0' : ''}
+            tabIndex={visible ? '0' : ''}
             aria-hidden={!visible}
             aria-pressed={opened ? !!selected : ''}
             aria-haspopup={!!selected}


### PR DESCRIPTION
This is something I missed in #283. Apparently React uses `tabIndex`, not `tabindex`.