### PR TITLE
fix: improve a11y of skin tone picker

### DIFF
--- a/src/components/skins-dot.js
+++ b/src/components/skins-dot.js
@@ -30,16 +30,20 @@ export default class SkinsDot extends Skins {
         <span
           key={`skin-tone-${skinTone}`}
           className={`emoji-mart-skin-swatch${selected ? ' selected' : ''}`}
+          aria-label={i18n.skintones[skinTone]}
+          aria-hidden={!visible}
+          {...opened && { role: 'menuitem' }}
         >
           <span
             onClick={this.handleClick}
             onKeyDown={this.handleKeyDown}
             role="button"
+            {...selected && {
+              'aria-haspopup': true,
+              'aria-expanded': !!opened,
+            }}
+            {...opened && { 'aria-pressed': !!selected }}
             tabIndex={visible ? '0' : ''}
-            aria-hidden={!visible}
-            aria-pressed={opened ? !!selected : ''}
-            aria-haspopup={!!selected}
-            aria-expanded={selected ? opened : ''}
             aria-label={i18n.skintones[skinTone]}
             title={i18n.skintones[skinTone]}
             data-skin={skinTone}
@@ -54,7 +58,7 @@ export default class SkinsDot extends Skins {
         className={`emoji-mart-skin-swatches${opened ? ' opened' : ''}`}
         aria-label={i18n.skintext}
       >
-        {skinToneNodes}
+        <div {...opened && { role: 'menubar' }}>{skinToneNodes}</div>
       </section>
     )
   }

--- a/src/components/skins-dot.js
+++ b/src/components/skins-dot.js
@@ -32,17 +32,17 @@ export default class SkinsDot extends Skins {
           className={`emoji-mart-skin-swatch${selected ? ' selected' : ''}`}
           aria-label={i18n.skintones[skinTone]}
           aria-hidden={!visible}
-          {...opened && { role: 'menuitem' }}
+          {...opened ? { role: 'menuitem' } : {}}
         >
           <span
             onClick={this.handleClick}
             onKeyDown={this.handleKeyDown}
             role="button"
-            {...selected && {
+            {...selected ? {
               'aria-haspopup': true,
               'aria-expanded': !!opened,
-            }}
-            {...opened && { 'aria-pressed': !!selected }}
+            } : {}}
+            {...opened ? { 'aria-pressed': !!selected } : {}}
             tabIndex={visible ? '0' : ''}
             aria-label={i18n.skintones[skinTone]}
             title={i18n.skintones[skinTone]}
@@ -58,7 +58,7 @@ export default class SkinsDot extends Skins {
         className={`emoji-mart-skin-swatches${opened ? ' opened' : ''}`}
         aria-label={i18n.skintext}
       >
-        <div {...opened && { role: 'menubar' }}>{skinToneNodes}</div>
+        <div {...opened ? { role: 'menubar' } : {}}>{skinToneNodes}</div>
       </section>
     )
   }


### PR DESCRIPTION
I don't think this is a full fix for #294 but it's a bit better than before. When the picker is not expanded, it's a popup button, then when you click it it becomes a toggle button within a menu item within a menu of similar buttons.

I tested this in NVDA and VoiceOver, and it works much better in NVDA than VoiceOver (VoiceOver doesn't seem to notice the toggle state for the buttons, nor the menu). But it's usable in either one.