### PR TITLE
fix: make each emoji category into a list

### DIFF
--- a/css/emoji-mart.css
+++ b/css/emoji-mart.css
@@ -160,6 +160,18 @@
   background-color: rgba(255, 255, 255, .95);
 }
 
+.emoji-mart-category-list {
+  margin: 0;
+  padding: 0;
+}
+
+.emoji-mart-category-list li {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: inline-block;
+}
+
 .emoji-mart-emoji {
   position: relative;
   display: inline-block;

--- a/src/components/category.js
+++ b/src/components/category.js
@@ -198,7 +198,7 @@ export default class Category extends React.Component {
         <ul className="emoji-mart-category-list">
         {emojis &&
           emojis.map((emoji) => (
-              <li>
+              <li key={emoji.id || emoji}>
                 {NimbleEmoji({ emoji: emoji, data: this.data, ...emojiProps })}
               </li>
             )

--- a/src/components/category.js
+++ b/src/components/category.js
@@ -195,10 +195,15 @@ export default class Category extends React.Component {
           </span>
         </div>
 
+        <ul className="emoji-mart-category-list">
         {emojis &&
-          emojis.map((emoji) =>
-            NimbleEmoji({ emoji: emoji, data: this.data, ...emojiProps }),
+          emojis.map((emoji) => (
+              <li>
+                {NimbleEmoji({ emoji: emoji, data: this.data, ...emojiProps })}
+              </li>
+            )
           )}
+        </ul>
 
         {emojis &&
           !emojis.length && (

--- a/src/components/emoji/nimble-emoji.js
+++ b/src/components/emoji/nimble-emoji.js
@@ -185,7 +185,6 @@ const NimbleEmoji = (props) => {
   } else {
     return (
       <button
-        key={props.emoji.id || props.emoji}
         onClick={(e) => _handleClick(e, props)}
         onMouseEnter={(e) => _handleOver(e, props)}
         onMouseLeave={(e) => _handleLeave(e, props)}


### PR DESCRIPTION
Fixes another a11y issue from #294.

Unfortunately I couldn't find a way to make these into lists/listitems without actually adding new `<li>`/`<ul>` elements. So this is potentially a performance hit by adding one more DOM node per list item. But I think it's worth it to make these lists more accessible.