### PR TITLE
fix: improve requestIdleCallback usage

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -192,18 +192,20 @@ function measureScrollbar() {
 // Use requestIdleCallback() if available, else fall back to setTimeout().
 // Throttle so as not to run too frequently.
 function throttleIdleTask(func) {
-  const queue =
+  const doIdleTask =
     typeof requestIdleCallback === 'function' ? requestIdleCallback : setTimeout
-  const clear =
-    typeof cancelIdleCallback === 'function' ? cancelIdleCallback : clearTimeout
 
-  let id
+  let running = false
 
   return function throttled() {
-    if (id) {
-      clear(id)
+    if (running) {
+      return
     }
-    id = queue(func)
+    running = true
+    doIdleTask(() => {
+      running = false
+      func()
+    })
   }
 }
 


### PR DESCRIPTION
It occurred to me that I was making this requestIdleCallback more complex than it needed to be. This simplifies it, and also avoids some unnecessary cancelIdleCallback calls.