### PR TITLE
chore: `yarn clean` should remove dist-modern

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "webpack": "^3.6.0"
   },
   "scripts": {
-    "clean": "rm -rf dist/ dist-es/",
+    "clean": "rm -rf dist/ dist-es/ dist-modern/",
     "build:data": "node scripts/build-data",
     "build:dist": "npm run build:cjs && npm run build:es && npm run build:modern",
     "build:cjs": "BABEL_ENV=legacy-cjs babel src --out-dir dist --copy-files",


### PR DESCRIPTION
This is something I missed when I added `dist-modern`