### PR TITLE
keep short_names on sanitize

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -31,6 +31,7 @@ function sanitize(emoji) {
     return {
       id,
       name,
+      short_names,
       colons,
       emoticons,
       custom,


### PR DESCRIPTION
https://github.com/missive/emoji-mart/blob/d739f27714c4b1e28f3d92f654a5ba83933c2816/src/components/emoji/nimble-emoji.js#L118

throws `TypeError: Cannot read property '0' of undefined`. (It makes https://github.com/tootsuite/mastodon/issues/10315 )

This is one of way to resolve issue, but it may not a good way.