### PR TITLE
fix: consistently return short_names from sanitize

### DIFF
--- a/src/utils/emoji-index/__tests__/emoji-index.test.js
+++ b/src/utils/emoji-index/__tests__/emoji-index.test.js
@@ -5,6 +5,7 @@ test('should work', () => {
     {
       id: 'pineapple',
       name: 'Pineapple',
+      short_names: ['pineapple'],
       colons: ':pineapple:',
       emoticons: [],
       unified: '1f34d',

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -46,6 +46,7 @@ function sanitize(emoji) {
   return {
     id,
     name,
+    short_names,
     colons,
     emoticons,
     unified: unified.toLowerCase(),


### PR DESCRIPTION
Based on #308 I am just going to assume that we always need to return `short_names` here. Admittedly, though, I haven't managed to write a Jest test to actually reproduce #308, nor can I prove that this is actually currently causing a bug. But it seems harmless to return `short_names` here.

