### PR TITLE
fix: use span for non-clickable emojis

### DIFF
--- a/src/components/__tests__/__snapshots__/not-found.test.js.snap
+++ b/src/components/__tests__/__snapshots__/not-found.test.js.snap
@@ -4,7 +4,7 @@ exports[`Renders <NotFound> component 1`] = `
 <div
   className="emoji-mart-no-results"
 >
-  <button
+  <span
     aria-label="🕵️, sleuth_or_spy"
     className="emoji-mart-emoji emoji-mart-emoji-native"
     onClick={[Function]}
@@ -25,7 +25,7 @@ exports[`Renders <NotFound> component 1`] = `
     >
       🕵️
     </span>
-  </button>
+  </span>
   <div
     className="emoji-mart-no-results-label"
   >

--- a/src/components/emoji/nimble-emoji.js
+++ b/src/components/emoji/nimble-emoji.js
@@ -185,7 +185,7 @@ const NimbleEmoji = (props) => {
   if (props.onClick) {
     Tag.name = 'button'
     Tag.props = {
-      type: 'button'
+      type: 'button',
     }
   }
 

--- a/src/components/emoji/nimble-emoji.js
+++ b/src/components/emoji/nimble-emoji.js
@@ -177,23 +177,36 @@ const NimbleEmoji = (props) => {
     }
   }
 
+  var Tag = {
+    name: 'span',
+    props: {},
+  }
+
+  if (props.onClick) {
+    Tag.name = 'button'
+    Tag.props = {
+      type: 'button'
+    }
+  }
+
   if (props.html) {
     style = _convertStyleToCSS(style)
-    return `<button style='${style}' aria-label='${label}' ${
+    return `<${Tag.name} style='${style}' aria-label='${label}' ${
       title ? `title='${title}'` : ''
-    } class='${className}'>${children || ''}</button>`
+    } class='${className}'>${children || ''}</${Tag.name}>`
   } else {
     return (
-      <button
+      <Tag.name
         onClick={(e) => _handleClick(e, props)}
         onMouseEnter={(e) => _handleOver(e, props)}
         onMouseLeave={(e) => _handleLeave(e, props)}
         aria-label={label}
         title={title}
         className={className}
+        {...Tag.props}
       >
         <span style={style}>{children}</span>
-      </button>
+      </Tag.name>
     )
   }
 }

--- a/src/utils/shared-default-props.js
+++ b/src/utils/shared-default-props.js
@@ -9,9 +9,6 @@ const EmojiDefaultProps = {
   tooltip: false,
   backgroundImageFn: (set, sheetSize) =>
     `https://unpkg.com/emoji-datasource-${set}@${EMOJI_DATASOURCE_VERSION}/img/${set}/sheets-256/${sheetSize}.png`,
-  onOver: () => {},
-  onLeave: () => {},
-  onClick: () => {},
 }
 
 const PickerDefaultProps = {


### PR DESCRIPTION
Fixes #309

- No more default `onClick` handler (undefined `props.onClick` was already handled)
- When `onClick` is defined, use `<Button>` with `type="button"` (see https://github.com/missive/emoji-mart/issues/309#issuecomment-476087144)