### PR TITLE
fix: ensure unique keys for React list

### DIFF
--- a/src/components/category.js
+++ b/src/components/category.js
@@ -204,7 +204,11 @@ export default class Category extends React.Component {
         <ul className="emoji-mart-category-list">
           {emojis &&
             emojis.map((emoji) => (
-              <li key={emoji.id || emoji}>
+              <li
+                key={
+                  (emoji.short_names && emoji.short_names.join('_')) || emoji
+                }
+              >
                 {NimbleEmoji({ emoji: emoji, data: this.data, ...emojiProps })}
               </li>
             ))}


### PR DESCRIPTION
fixes #327

Probably the `id` in the index itself should be guaranteed to be unique as well, but this at least fixes the React warning.