### PR TITLE
Keep auto focus when changing category

### DIFF
--- a/src/components/picker/nimble-picker.js
+++ b/src/components/picker/nimble-picker.js
@@ -388,6 +388,8 @@ export default class NimblePicker extends React.PureComponent {
     } else {
       scrollToComponent()
     }
+
+    this.search.focus()
   }
 
   handleSkinChange(skin) {

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -21,6 +21,7 @@ export default class Search extends React.PureComponent {
     this.setRef = this.setRef.bind(this)
     this.clear = this.clear.bind(this)
     this.handleKeyUp = this.handleKeyUp.bind(this)
+    this.focus = this.focus.bind(this)
 
     // throttle keyboard input so that typing isn't delayed
     this.handleChange = throttleIdleTask(this.handleChange.bind(this))
@@ -62,6 +63,11 @@ export default class Search extends React.PureComponent {
     this.input.value = ''
     this.input.focus()
     this.search('')
+  }
+
+  focus() {
+    const { autoFocus } = this.props
+    if (autoFocus) this.input.focus()
   }
 
   handleChange() {


### PR DESCRIPTION
Suggestion:

If autofocus is true, keep search input focused when changing between emoji categories to still allow for quick search.