### PR TITLE
Use getDerivedStateFromProps instead of componentWillReceiveProps

### DIFF
--- a/src/components/picker/nimble-picker.js
+++ b/src/components/picker/nimble-picker.js
@@ -176,12 +176,19 @@ export default class NimblePicker extends React.PureComponent {
     this.handleKeyDown = this.handleKeyDown.bind(this)
   }
 
-  componentWillReceiveProps(props) {
+  static getDerivedStateFromProps(props, state) {
     if (props.skin) {
-      this.setState({ skin: props.skin })
+      return {
+        ...state,
+        skin: props.skin
+      }
     } else if (props.defaultSkin && !store.get('skin')) {
-      this.setState({ skin: props.defaultSkin })
+      return {
+        ...state,
+        skin: props.defaultSkin
+      }
     }
+    return state
   }
 
   componentDidMount() {

--- a/src/components/picker/nimble-picker.js
+++ b/src/components/picker/nimble-picker.js
@@ -180,12 +180,12 @@ export default class NimblePicker extends React.PureComponent {
     if (props.skin) {
       return {
         ...state,
-        skin: props.skin
+        skin: props.skin,
       }
     } else if (props.defaultSkin && !store.get('skin')) {
       return {
         ...state,
-        skin: props.defaultSkin
+        skin: props.defaultSkin,
       }
     }
     return state


### PR DESCRIPTION
`componentWillReceiveProps` will be removed from React 17.x. So, I use `getDerivedStateFromProps` instead of it. 

This pull request solves issue #356.