### PR TITLE
Move `With custom data` to correct position

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,15 @@ emojiIndex.search('christmas').map((o) => o.native)
 // => [🎄, 🎅🏼, 🔔, 🎁, ⛄️, ❄️]
 ```
 
+### With custom data
+```js
+import data from 'emoji-mart/datasets/messenger'
+import { NimbleEmojiIndex } from 'emoji-mart'
+
+let emojiIndex = new NimbleEmojiIndex(data)
+emojiIndex.search('christmas')
+```
+
 ## Get emoji data from Native
 You can get emoji data from native emoji unicode using the `getEmojiDataFromNative` util function.
 
@@ -331,15 +340,6 @@ emojiData: {
   "skin": 4,
   "native": "🏊🏽‍♀️"
 }
-```
-
-### With custom data
-```js
-import data from 'emoji-mart/datasets/messenger'
-import { NimbleEmojiIndex } from 'emoji-mart'
-
-let emojiIndex = new NimbleEmojiIndex(data)
-emojiIndex.search('christmas')
 ```
 
 ## Storage


### PR DESCRIPTION
Looks like the `With custom data` section of `Headless search` got pushed down by the `Get emoji data from Native` stuff.