### PR TITLE
fix: gracefully ignore bad JSON in localstorage

### DIFF
--- a/src/utils/store.js
+++ b/src/utils/store.js
@@ -44,12 +44,12 @@ function get(key) {
     if (!isLocalStorageSupported) return
     try {
       var value = window.localStorage[`${NAMESPACE}.${key}`]
+
+      if (value) {
+        return JSON.parse(value)
+      }
     } catch (e) {
       return
-    }
-
-    if (value) {
-      return JSON.parse(value)
     }
   }
 }


### PR DESCRIPTION
# Background
We were previously using an [Angular port](https://github.com/TypeCtrl/ngx-emoji-mart) of emoji-mart, then we migrated our application to React, and began using the original emoji-mart.  That port used the `emoji-mart.last` localstorage item slightly differently, by not JSON-encoding it. After the migration, our app would crash while rendering emoji-mart, as it attempted to parse the stale value from our users' localstorage.

# Changes
This PR changes the store's behaviour to discard invalid JSON values instead of raising an error through `JSON.parse`. That way, if those values ever become corrupt or otherwise invalid for some reason, things like recent emoji just get forgotten, instead of the app inexplicably crashing.