### PR TITLE
Fix: Allowing emoji selection on enter

### DIFF
--- a/src/components/picker/nimble-picker.js
+++ b/src/components/picker/nimble-picker.js
@@ -418,9 +418,9 @@ export default class NimblePicker extends React.PureComponent {
           ))
         ) {
           this.handleEmojiSelect(emoji)
+          handled = true
         }
 
-        handled = true
         break
     }
 


### PR DESCRIPTION
The `handled` variable should only be set when we actually call the `handleEmojiSelect` function, otherwise it overrides default button behaviour of being selectable by the enter key. 

This causes an issue for accessible keyboard navigation: https://webaim.org/techniques/keyboard/

Fixes #353 