### PR TITLE
fix: remove core-js dependency

### DIFF
--- a/src/components/picker/nimble-picker.js
+++ b/src/components/picker/nimble-picker.js
@@ -105,7 +105,9 @@ export default class NimblePicker extends React.PureComponent {
         this.CUSTOM.push(customEmoji)
       })
 
-      allCategories.push(...Object.values(customCategories))
+      allCategories = allCategories.concat(
+        Object.keys(customCategories).map((key) => customCategories[key]),
+      )
     }
 
     this.hideRecent = true

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -5,6 +5,8 @@ import { uncompress } from './data'
 const COLONS_REGEX = /^(?:\:([^\:]+)\:)(?:\:skin-tone-(\d)\:)?$/
 const SKINS = ['1F3FA', '1F3FB', '1F3FC', '1F3FD', '1F3FE', '1F3FF']
 
+const _JSON = JSON // don't let babel include all of core-js for stringify/parse
+
 function unifiedToNative(unified) {
   var unicodes = unified.split('-'),
     codePoints = unicodes.map((u) => `0x${u}`)
@@ -107,7 +109,7 @@ function getData(emoji, skin, set, data) {
   emojiData.variations || (emojiData.variations = [])
 
   if (emojiData.skin_variations && skin > 1) {
-    emojiData = JSON.parse(JSON.stringify(emojiData))
+    emojiData = _JSON.parse(_JSON.stringify(emojiData))
 
     var skinKey = SKINS[skin - 1],
       variationData = emojiData.skin_variations[skinKey]
@@ -132,7 +134,7 @@ function getData(emoji, skin, set, data) {
   }
 
   if (emojiData.variations && emojiData.variations.length) {
-    emojiData = JSON.parse(JSON.stringify(emojiData))
+    emojiData = _JSON.parse(_JSON.stringify(emojiData))
     emojiData.unified = emojiData.variations.shift()
   }
 

--- a/src/utils/store.js
+++ b/src/utils/store.js
@@ -3,6 +3,8 @@ var NAMESPACE = 'emoji-mart'
 var isLocalStorageSupported =
   typeof window !== 'undefined' && 'localStorage' in window
 
+const _JSON = JSON // don't let babel include all of core-js for stringify/parse
+
 let getter
 let setter
 
@@ -30,7 +32,7 @@ function set(key, value) {
   } else {
     if (!isLocalStorageSupported) return
     try {
-      window.localStorage[`${NAMESPACE}.${key}`] = JSON.stringify(value)
+      window.localStorage[`${NAMESPACE}.${key}`] = _JSON.stringify(value)
     } catch (e) {}
   }
 }
@@ -44,7 +46,7 @@ function get(key) {
       var value = window.localStorage[`${NAMESPACE}.${key}`]
 
       if (value) {
-        return JSON.parse(value)
+        return _JSON.parse(value)
       }
     } catch (e) {
       return


### PR DESCRIPTION
Fixes #393 

This removes `core-js` from our output bundle... for now. In the future, we need to come up with a better system for ensuring that Babel doesn't include `core-js` in our bundle.