### PR TITLE
test: add test for emoji-index.js

### DIFF
--- a/src/utils/emoji-index/__tests__/emoji-index.test.js
+++ b/src/utils/emoji-index/__tests__/emoji-index.test.js
@@ -39,3 +39,13 @@ test('can search for woman-facepalming', () => {
     'woman-facepalming',
   ])
 })
+
+test('emojiIndex exports emojis', () => {
+  const emojis = emojiIndex.emojis
+  expect(emojis['thinking_face'].native).toEqual('\ud83e\udd14')
+})
+
+test('emojiIndex exports emoticons', () => {
+  const emoticons = emojiIndex.emoticons
+  expect(emoticons[':)']).toEqual('slightly_smiling_face')
+})


### PR DESCRIPTION
We expose the `emojis` and `emoticons` objects from `emoji-index.js` but they weren't tested anywhere as far as I can tell. This adds a test for them.