### PR TITLE
test: test bundle size in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 script: yarn test
 before_script:
 - yarn prettier:check
+- yarn test:size
 branches:
   only:
   - master

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "react:14": "npm run react:clean && npm i react@^0.14 react-dom@^0.14 react-addons-test-utils@^0.14 --save-dev",
     "react:15": "npm run react:clean && npm i react@^15 react-dom@^15 react-addons-test-utils@^15 --save-dev",
     "test": "npm run clean && jest",
+    "test:size": "size-limit",
     "prepublishOnly": "npm run build",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",


### PR DESCRIPTION
We have this test (to keep the size under 80kB), but it's not currently running in CI. This fixes that.