### PR TITLE
refactor: remove _JSON

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -5,8 +5,6 @@ import { uncompress } from './data'
 const COLONS_REGEX = /^(?:\:([^\:]+)\:)(?:\:skin-tone-(\d)\:)?$/
 const SKINS = ['1F3FA', '1F3FB', '1F3FC', '1F3FD', '1F3FE', '1F3FF']
 
-const _JSON = JSON // don't let babel include all of core-js for stringify/parse
-
 function unifiedToNative(unified) {
   var unicodes = unified.split('-'),
     codePoints = unicodes.map((u) => `0x${u}`)
@@ -109,7 +107,7 @@ function getData(emoji, skin, set, data) {
   emojiData.variations || (emojiData.variations = [])
 
   if (emojiData.skin_variations && skin > 1) {
-    emojiData = _JSON.parse(_JSON.stringify(emojiData))
+    emojiData = JSON.parse(JSON.stringify(emojiData))
 
     var skinKey = SKINS[skin - 1],
       variationData = emojiData.skin_variations[skinKey]
@@ -134,7 +132,7 @@ function getData(emoji, skin, set, data) {
   }
 
   if (emojiData.variations && emojiData.variations.length) {
-    emojiData = _JSON.parse(_JSON.stringify(emojiData))
+    emojiData = JSON.parse(JSON.stringify(emojiData))
     emojiData.unified = emojiData.variations.shift()
   }
 

--- a/src/utils/store.js
+++ b/src/utils/store.js
@@ -3,8 +3,6 @@ var NAMESPACE = 'emoji-mart'
 var isLocalStorageSupported =
   typeof window !== 'undefined' && 'localStorage' in window
 
-const _JSON = JSON // don't let babel include all of core-js for stringify/parse
-
 let getter
 let setter
 
@@ -32,7 +30,7 @@ function set(key, value) {
   } else {
     if (!isLocalStorageSupported) return
     try {
-      window.localStorage[`${NAMESPACE}.${key}`] = _JSON.stringify(value)
+      window.localStorage[`${NAMESPACE}.${key}`] = JSON.stringify(value)
     } catch (e) {}
   }
 }
@@ -46,7 +44,7 @@ function get(key) {
       var value = window.localStorage[`${NAMESPACE}.${key}`]
 
       if (value) {
-        return _JSON.parse(value)
+        return JSON.parse(value)
       }
     } catch (e) {
       return


### PR DESCRIPTION
I can confirm that, once #397 is merged, then we no longer need this hack (which avoided `core-js`/`@babel/runtime` from including a large polyfill). That makes sense, since JSON has been available [since IE8](https://caniuse.com/#feat=json).