### PR TITLE
safely access this.input.value

### DIFF
--- a/src/components/search.js
+++ b/src/components/search.js
@@ -65,7 +65,9 @@ export default class Search extends React.PureComponent {
   }
 
   handleChange() {
-    this.search(this.input.value)
+    if (this.input) {
+      this.search(this.input.value)
+    }
   }
 
   handleKeyUp(e) {


### PR DESCRIPTION
not really sure how to reproduce, but apparently one of my users managed to time their search perfectly (probably due to the throttle?).

this should prevent that.

<img width="677" alt="Screen Shot 2020-03-18 at 11 15 10 AM" src="https://user-images.githubusercontent.com/5514175/76982342-c17c6a80-6909-11ea-9b8d-1ee892f550f5.png">
