### PR TITLE
added padding around emoji hover

### DIFF
--- a/css/emoji-mart.css
+++ b/css/emoji-mart.css
@@ -144,6 +144,7 @@
   width: 100%; height: 100%;
   background-color: #f4f4f4;
   border-radius: 100%;
+  padding: 3px;
 }
 
 .emoji-mart-category-label {


### PR DESCRIPTION
Currently, when hovering over the emoji, the emoji is not centered inside the round hover area.

![image](https://user-images.githubusercontent.com/53095479/80208214-67717200-8638-11ea-9d20-26a247396933.png)

I added padding to the ::before and now when hovering over an emoji, it is perfectly centered. 🙂

![image](https://user-images.githubusercontent.com/53095479/80208372-b8816600-8638-11ea-9a55-c337bfc91abb.png)
