### PR TITLE
Fix native

### DIFF
--- a/css/emoji-mart.css
+++ b/css/emoji-mart.css
@@ -215,14 +215,9 @@
 .emoji-mart-preview {
   position: relative;
   height: 70px;
-}
-
-.emoji-mart-preview-emoji,
-.emoji-mart-preview-data,
-.emoji-mart-preview-skins {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 }
 
 .emoji-mart-preview-emoji {
@@ -232,9 +227,11 @@
 .emoji-mart-preview-data {
   left: 68px; right: 12px;
   word-break: break-all;
+  flex: 1;
 }
 
 .emoji-mart-preview-skins {
+  position: absolute;
   right: 30px;
   text-align: right;
 }

--- a/src/components/__tests__/__snapshots__/not-found.test.js.snap
+++ b/src/components/__tests__/__snapshots__/not-found.test.js.snap
@@ -10,6 +10,16 @@ exports[`Renders <NotFound> component 1`] = `
     onClick={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
+    style={
+      Object {
+        "boxSizing": "content-box",
+        "display": "inline-block",
+        "height": 38,
+        "position": "relative",
+        "verticalAlign": "bottom",
+        "width": 38,
+      }
+    }
     title={null}
   >
     <span
@@ -17,8 +27,10 @@ exports[`Renders <NotFound> component 1`] = `
         Object {
           "display": "inline-block",
           "fontSize": 38,
-          "height": 38,
-          "width": 38,
+          "left": "50%",
+          "position": "absolute",
+          "top": "50%",
+          "transform": "translate(-50%, -50%)",
           "wordBreak": "keep-all",
         }
       }

--- a/src/components/emoji/nimble-emoji.js
+++ b/src/components/emoji/nimble-emoji.js
@@ -118,16 +118,34 @@ const NimbleEmoji = (props) => {
     title = short_names[0]
   }
 
+  var Tag = {
+    name: 'span',
+    props: {
+      style: {
+        verticalAlign: 'bottom'
+      }
+    },
+  }
+
   if (props.native && unified) {
     className += ' emoji-mart-emoji-native'
     style = { fontSize: props.size }
     children = nativeEmoji
-
     if (props.forceSize) {
-      style.display = 'inline-block'
-      style.width = props.size
-      style.height = props.size
-      style.wordBreak = 'keep-all'
+      Tag.props.style = {
+        ...Tag.props.style,
+        width: props.size,
+        height: props.size,
+        position: 'relative',
+        display: 'inline-block',
+        boxSizing: 'content-box',
+      }
+      style.display = 'inline-block';
+      style.wordBreak = 'keep-all';
+      style.position = 'absolute';
+      style.top = '50%';
+      style.left = '50%';
+      style.transform = 'translate(-50%, -50%)';
     }
   } else if (custom) {
     className += ' emoji-mart-emoji-custom'
@@ -179,14 +197,10 @@ const NimbleEmoji = (props) => {
     }
   }
 
-  var Tag = {
-    name: 'span',
-    props: {},
-  }
-
   if (props.onClick && props.useButton) {
     Tag.name = 'button'
     Tag.props = {
+      ...Tag.props,
       type: 'button',
     }
   }

--- a/src/components/emoji/nimble-emoji.js
+++ b/src/components/emoji/nimble-emoji.js
@@ -121,10 +121,15 @@ const NimbleEmoji = (props) => {
   var Tag = {
     name: 'span',
     props: {
-      style: {
-        verticalAlign: 'bottom'
-      }
+      style: {},
     },
+  }
+
+  if (props.forceSize) {
+    Tag.props.style = {
+      ...Tag.props.style,
+      verticalAlign: 'bottom',
+    }
   }
 
   if (props.native && unified) {
@@ -140,12 +145,12 @@ const NimbleEmoji = (props) => {
         display: 'inline-block',
         boxSizing: 'content-box',
       }
-      style.display = 'inline-block';
-      style.wordBreak = 'keep-all';
-      style.position = 'absolute';
-      style.top = '50%';
-      style.left = '50%';
-      style.transform = 'translate(-50%, -50%)';
+      style.display = 'inline-block'
+      style.wordBreak = 'keep-all'
+      style.position = 'absolute'
+      style.top = '50%'
+      style.left = '50%'
+      style.transform = 'translate(-50%, -50%)'
     }
   } else if (custom) {
     className += ' emoji-mart-emoji-custom'
@@ -220,7 +225,9 @@ const NimbleEmoji = (props) => {
         title={title}
         className={className}
         {...Tag.props}
-      ><span style={style}>{children}</span></Tag.name>
+      >
+        <span style={style}>{children}</span>
+      </Tag.name>
     )
   }
 }

--- a/src/components/emoji/nimble-emoji.js
+++ b/src/components/emoji/nimble-emoji.js
@@ -220,9 +220,7 @@ const NimbleEmoji = (props) => {
         title={title}
         className={className}
         {...Tag.props}
-      >
-        <span style={style}>{children}</span>
-      </Tag.name>
+      ><span style={style}>{children}</span></Tag.name>
     )
   }
 }


### PR DESCRIPTION
Fix display issues of native emojis in #319 and #310.

This PR does not fix emojis on Windows 10 that are shown as 2 separate emoji's e.g. pilot.
A quick fix for this issue is to filter out all `person zero-width-joiner` emojis with: 
```
emojisToShowFilter={(emoji) => !emoji.unified || !emoji.unified.startsWith('1F9D1-')}
```

A more detailed filter can be found in #443 