### PR TITLE
Option to provide an own class name to custom emojis

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,8 @@ const customEmojis = [
     emoticons: [],
     keywords: ['github'],
     imageUrl: 'https://github.githubassets.com/images/icons/emoji/octocat.png',
-    customCategory: 'GitHub'
+    customCategory: 'GitHub',
+    className: 'gh-octocat'
   },
   {
     name: 'Test Flag',
@@ -268,6 +269,8 @@ const customEmojis = [
 
 The `customCategory` string is optional. If you include it, then the custom emoji will be shown in whatever
 categories you define. If you don't include it, then there will just be one category called "Custom."
+
+The `className` string is optional too. It allows you to set an own CSS class for the custom emoji. 
 
 ## Not Found
 You can provide a custom Not Found object which will allow the appearance of the not found search results to change. In this case, we change the default 'sleuth_or_spy' emoji to Octocat when our search finds no results.

--- a/src/components/__tests__/__snapshots__/not-found.test.js.snap
+++ b/src/components/__tests__/__snapshots__/not-found.test.js.snap
@@ -13,6 +13,7 @@ exports[`Renders <NotFound> component 1`] = `
     title={null}
   >
     <span
+      className=""
       style={
         Object {
           "display": "inline-block",

--- a/src/components/emoji/nimble-emoji.js
+++ b/src/components/emoji/nimble-emoji.js
@@ -207,7 +207,9 @@ const NimbleEmoji = (props) => {
         className={className}
         {...Tag.props}
       >
-        <span style={style}>{children}</span>
+        <span style={style} className={data.className || ''}>
+          {children}
+        </span>
       </Tag.name>
     )
   }

--- a/stories/index.js
+++ b/stories/index.js
@@ -29,6 +29,7 @@ const CUSTOM_EMOJIS = [
     short_names: ['octocat'],
     keywords: ['github'],
     imageUrl: 'https://github.githubassets.com/images/icons/emoji/octocat.png',
+    className: 'gh-octocat',
   },
   {
     name: 'Squirrel',


### PR DESCRIPTION
Sometimes you need to set some special CSS attributes to make a custom emoji perfectly displayed. Until now, you only could style all custom emojis in general with the `emoji-mart-emoji-custom` class. But if you use emoji images from different sources, you maybe want to change some settings of individual custom emojis.

This PR adds support for an attribute `className` which may be added to the declaration of a custom emoji. The value of this attribute will then be added as class name to the custom emoji element.