### PR TITLE
Add possibility to add window context from which requestAnimationFrame should be fired

### DIFF
--- a/src/utils/shared-default-props.js
+++ b/src/utils/shared-default-props.js
@@ -42,6 +42,7 @@ const PickerDefaultProps = {
   notFound: () => {},
   notFoundEmoji: 'sleuth_or_spy',
   icons: {},
+  windowContext: null,
 }
 
 export { PickerDefaultProps, EmojiDefaultProps }

--- a/src/utils/shared-props.js
+++ b/src/utils/shared-props.js
@@ -66,6 +66,7 @@ const PickerPropTypes = {
   notFound: PropTypes.func,
   notFoundEmoji: PropTypes.string,
   icons: PropTypes.object,
+  windowContext: PropTypes.object,
 }
 
 export { EmojiPropTypes, PickerPropTypes }


### PR DESCRIPTION
When using incorrect window context some browsers (e.g. firefox) will silently fail to call requestAnimationFrame.

This PR introduces windowContext prop which allows to pass window object directly into `NimblePicker` component.