### PR TITLE
feat(picker): add new categoryHeight parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ import { Picker } from 'emoji-mart'
 | **notFoundEmoji** | | `sleuth_or_spy` | The emoji shown when there are no search results |
 | **notFound** | | | [Not Found](#not-found) |
 | **icons** | | `{}` | [Custom icons](#custom-icons) |
+| **categoryHeight** | | `270px` | Category container height  |
 
 #### I18n
 ```js

--- a/css/emoji-mart.css
+++ b/css/emoji-mart.css
@@ -88,7 +88,6 @@
 .emoji-mart-scroll {
   overflow-y: scroll;
   overflow-x: hidden;
-  height: 270px;
   padding: 0 6px 6px 6px;
   will-change: transform; /* avoids "repaints on scroll" in mobile Chrome */
 }

--- a/docs/emoji-mart.css
+++ b/docs/emoji-mart.css
@@ -88,7 +88,6 @@
 .emoji-mart-scroll {
   overflow-y: scroll;
   overflow-x: hidden;
-  height: 270px;
   padding: 0 6px 6px 6px;
   will-change: transform; /* avoids "repaints on scroll" in mobile Chrome */
 }

--- a/src/components/picker/nimble-picker.js
+++ b/src/components/picker/nimble-picker.js
@@ -534,6 +534,7 @@ export default class NimblePicker extends React.PureComponent {
       skinEmoji,
       notFound,
       notFoundEmoji,
+      categoryHeight,
     } = this.props
 
     var width = perLine * (emojiSize + 12) + 12 + 2 + measureScrollbar()
@@ -579,6 +580,7 @@ export default class NimblePicker extends React.PureComponent {
           ref={this.setScrollRef}
           className="emoji-mart-scroll"
           onScroll={this.handleScroll}
+          style={{ height: categoryHeight }}
         >
           {this.getCategories().map((category, i) => {
             return (

--- a/src/utils/shared-default-props.js
+++ b/src/utils/shared-default-props.js
@@ -42,6 +42,7 @@ const PickerDefaultProps = {
   notFound: () => {},
   notFoundEmoji: 'sleuth_or_spy',
   icons: {},
+  categoryHeight: '270px',
 }
 
 export { PickerDefaultProps, EmojiDefaultProps }

--- a/src/utils/shared-props.js
+++ b/src/utils/shared-props.js
@@ -66,6 +66,7 @@ const PickerPropTypes = {
   notFound: PropTypes.func,
   notFoundEmoji: PropTypes.string,
   icons: PropTypes.object,
+  categoryHeight: PropTypes.string,
 }
 
 export { EmojiPropTypes, PickerPropTypes }


### PR DESCRIPTION
# Description

Actually ```.emoji-mart-scroll``` css class contains a fixed height size. It's not possible to define a number of lines for emojis in category.

<img width="494" alt="Capture d’écran 2020-10-28 à 18 36 46" src="https://user-images.githubusercontent.com/11146088/97475405-80434300-194d-11eb-8bb3-173786762982.png">

For more flexibility, I suggest to add a categoryHeight parameter.

## Type of change

- [ ] Bug fix 
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update