### PR TITLE
Fix aria-label and title for custom categories

### DIFF
--- a/src/components/anchors.js
+++ b/src/components/anchors.js
@@ -41,9 +41,9 @@ export default class Anchors extends React.PureComponent {
 
           return (
             <button
-              key={id}
-              aria-label={i18n.categories[id]}
-              title={i18n.categories[id]}
+              key={iconId}
+              aria-label={i18n.categories[iconId]}
+              title={i18n.categories[iconId]}
               data-index={i}
               type={'button'}
               onClick={this.handleClick}


### PR DESCRIPTION
The aria-label and title weren't showing up for the Custom button.  

<img width="546" alt="Screen Shot 2021-01-20 at 3 59 59 PM" src="https://user-images.githubusercontent.com/6962590/105251401-a46f8400-5b38-11eb-8676-bf7bd03809ea.png">
