### PR TITLE
setSearchRef function

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ import { Picker } from 'emoji-mart'
 | **notFoundEmoji** | | `sleuth_or_spy` | The emoji shown when there are no search results |
 | **notFound** | | | [Not Found](#not-found) |
 | **icons** | | `{}` | [Custom icons](#custom-icons) |
+| **setSearchRef** | | | You can pass a function to that sets search ref |
 
 #### I18n
 ```js

--- a/src/components/picker/nimble-picker.js
+++ b/src/components/picker/nimble-picker.js
@@ -490,6 +490,7 @@ export default class NimblePicker extends React.PureComponent {
 
   setSearchRef(c) {
     this.search = c
+    this.props.setSearchRef(c)
   }
 
   setPreviewRef(c) {

--- a/src/utils/shared-default-props.js
+++ b/src/utils/shared-default-props.js
@@ -16,6 +16,7 @@ const PickerDefaultProps = {
   onClick: () => {},
   onSelect: () => {},
   onSkinChange: () => {},
+  setSearchRef: () => {},
   emojiSize: 24,
   perLine: 9,
   i18n: {},

--- a/src/utils/shared-props.js
+++ b/src/utils/shared-props.js
@@ -66,6 +66,7 @@ const PickerPropTypes = {
   notFound: PropTypes.func,
   notFoundEmoji: PropTypes.string,
   icons: PropTypes.object,
+  setSearchRef: PropTypes.func,
 }
 
 export { EmojiPropTypes, PickerPropTypes }


### PR DESCRIPTION
## Why?

Sometimes you might want to access ref of search input in the parent component if autoFocus is not enough and you need more control. Right now that prop is not possible

## Related issues

closes https://github.com/missive/emoji-mart/issues/416

## How does this work?

1. This PR adds a prop `setSearchRef` which would allow you to pass a function which will set the search ref 
2. The reason it did not use ref forwarding is because if we want to add more refs for other things this keeps things simple and also this method of passing function to set ref is also used internally 

### Does this code have tests ?
- I might need some help writing tests for this

### README / Documentation update ?
- Yes I have updated README.md with prop in the prop list
