### PR TITLE
Allow emoji to have a class given

### DIFF
--- a/src/components/emoji/nimble-emoji.js
+++ b/src/components/emoji/nimble-emoji.js
@@ -179,6 +179,10 @@ const NimbleEmoji = (props) => {
     }
   }
 
+  if (props.className) {
+    className += ` ${props.className}`
+  }
+
   var Tag = {
     name: 'span',
     props: {},
@@ -193,9 +197,8 @@ const NimbleEmoji = (props) => {
 
   if (props.html) {
     style = _convertStyleToCSS(style)
-    return `<${Tag.name} style='${style}' aria-label='${label}' ${
-      title ? `title='${title}'` : ''
-    } class='${className}'>${children || ''}</${Tag.name}>`
+    return `<${Tag.name} style='${style}' aria-label='${label}' ${title ? `title='${title}'` : ''
+      } class='${className}'>${children || ''}</${Tag.name}>`
   } else {
     return (
       <Tag.name

--- a/src/utils/shared-props.js
+++ b/src/utils/shared-props.js
@@ -18,6 +18,7 @@ const EmojiPropTypes = {
   set: PropTypes.oneOf(['apple', 'google', 'twitter', 'facebook']),
   size: PropTypes.number.isRequired,
   emoji: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
+  className: PropTypes.string,
 }
 
 const PickerPropTypes = {


### PR DESCRIPTION
A small update in which I have added the ability to pass through a Class Name that gets merged with the other class names in the Nimble Emoji component.

This feature would be a great addition, as it allows some repositioning and movement of the final emoji, which may be required when using external packages such as MUI. A problem I encountered using this component is that the Emoji were always ~4px above center line, when using centered emoji.

Example Use Case:
_before_
![image](https://user-images.githubusercontent.com/37277599/160240981-efbf7245-526f-4030-92f8-19a114e6f2e5.png)

_after_
![image](https://user-images.githubusercontent.com/37277599/160241002-ca043f30-94db-4f93-9617-bf2a7d830775.png)
