### PR TITLE
fix issue with error intermittently being thrown during jest testing

### DIFF
--- a/src/components/category.js
+++ b/src/components/category.js
@@ -64,14 +64,15 @@ export default class Category extends React.Component {
   }
 
   memoizeSize() {
-    if (!this.container) {
+    const containerRect = this.container && this.container.getBoundingClientRect()
+    if (!containerRect) {
       // probably this is a test environment, e.g. jest
       this.top = 0
       this.maxMargin = 0
       return
     }
     var parent = this.container.parentElement
-    var { top, height } = this.container.getBoundingClientRect()
+    var { top, height } = containerRect
     var { top: parentTop } = parent.getBoundingClientRect()
     var { height: labelHeight } = this.label.getBoundingClientRect()
 


### PR DESCRIPTION
Intermittently, when running Jest tests for a custom component that internally uses the `Picker` component from emoji-mart, the following error will be thrown:

```
TypeError: Cannot read property 'top' of undefined
    at Category.memoizeSize (/usr/src/app/node_modules/emoji-mart/dist/components/category.js:113:39)
    at Category.componentDidMount (/usr/src/app/node_modules/emoji-mart/dist/components/category.js:61:12)
    at commitLifeCycles (/usr/src/app/node_modules/react-dom/cjs/react-dom.development.js:19814:22)
    at commitLayoutEffects (/usr/src/app/node_modules/react-dom/cjs/react-dom.development.js:22803:7)
    at HTMLUnknownElement.callCallback (/usr/src/app/node_modules/react-dom/cjs/react-dom.development.js:188:14)
    at innerInvokeEventListeners (/usr/src/app/node_modules/jest-environment-jsdom-fourteen/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:315:27)
    at invokeEventListeners (/usr/src/app/node_modules/jest-environment-jsdom-fourteen/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:266:3)
    at HTMLUnknownElementImpl._dispatch (/usr/src/app/node_modules/jest-environment-jsdom-fourteen/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:212:11)
    at HTMLUnknownElementImpl.dispatchEvent (/usr/src/app/node_modules/jest-environment-jsdom-fourteen/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:87:17)
    at HTMLUnknownElement.dispatchEvent (/usr/src/app/node_modules/jest-environment-jsdom-fourteen/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:144:23)
    at Object.invokeGuardedCallbackDev (/usr/src/app/node_modules/react-dom/cjs/react-dom.development.js:237:16)
    at invokeGuardedCallback (/usr/src/app/node_modules/react-dom/cjs/react-dom.development.js:292:31)
    at commitRootImpl (/usr/src/app/node_modules/react-dom/cjs/react-dom.development.js:22541:9)
    at unstable_runWithPriority (/usr/src/app/node_modules/scheduler/cjs/scheduler.development.js:653:12)
    at runWithPriority$1 (/usr/src/app/node_modules/react-dom/cjs/react-dom.development.js:11039:10)
    at commitRoot (/usr/src/app/node_modules/react-dom/cjs/react-dom.development.js:22381:3)
    at finishSyncRender (/usr/src/app/node_modules/react-dom/cjs/react-dom.development.js:21807:3)
    at performSyncWorkOnRoot (/usr/src/app/node_modules/react-dom/cjs/react-dom.development.js:21793:7)
    at /usr/src/app/node_modules/react-dom/cjs/react-dom.development.js:11089:24
    at unstable_runWithPriority (/usr/src/app/node_modules/scheduler/cjs/scheduler.development.js:653:12)
    at runWithPriority$1 (/usr/src/app/node_modules/react-dom/cjs/react-dom.development.js:11039:10)
    at flushSyncCallbackQueueImpl (/usr/src/app/node_modules/react-dom/cjs/react-dom.development.js:11084:7)
    at flushSyncCallbackQueue (/usr/src/app/node_modules/react-dom/cjs/react-dom.development.js:11072:3)
    at batchedUpdates$1 (/usr/src/app/node_modules/react-dom/cjs/react-dom.development.js:21862:7)
    at act (/usr/src/app/node_modules/react-dom/cjs/react-dom-test-utils.development.js:929:14)
    at Object.eventWrapper (/usr/src/app/node_modules/@testing-library/react/dist/pure.js:65:28)
    at fireEvent (/usr/src/app/node_modules/@testing-library/dom/dist/events.js:16:35)
    at Function.fireEvent.<computed> [as click] (/usr/src/app/node_modules/@testing-library/dom/dist/events.js:125:36)
    at clickElement (/usr/src/app/node_modules/@testing-library/user-event/dist/click.js:90:20)
    at Object.click (/usr/src/app/node_modules/@testing-library/user-event/dist/click.js:136:7)
    at Object.<anonymous> (/usr/src/app/ui/shared/emoji/react/__tests__/EmojiPicker.test.js:53:15)
    at Object.asyncJestTest (/usr/src/app/node_modules/jest-jasmine2/build/jasmineAsyncInstall.js:106:37)
    at /usr/src/app/node_modules/jest-jasmine2/build/queueRunner.js:45:12
    at new Promise (<anonymous>)
    at mapper (/usr/src/app/node_modules/jest-jasmine2/build/queueRunner.js:28:19)
    at /usr/src/app/node_modules/jest-jasmine2/build/queueRunner.js:75:41
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```
    
The problem is that `this.container` _does_ exist, but `this.container.getBoundingClientRect()` returns `undefined`. The existing check in place to detect a Jest run checks to see if `this.container` is present. The change in this commit assumes we're in a Jest run if _either_ A) `this.container` is not present OR B) `this.container` exists, but `this.container.getBoundingClientRect()` is undefined