### PR TITLE
Add type=button to search box clear button

### DIFF
--- a/src/components/search.js
+++ b/src/components/search.js
@@ -108,6 +108,7 @@ export default class Search extends React.PureComponent {
           onKeyUp={this.handleKeyUp}
           aria-label={i18n.clear}
           disabled={!isSearching}
+          type="button"
         >
           {icon()}
         </button>


### PR DESCRIPTION
When the picker is in a form, clicking the 'clear' button currently submits the form. I could only reproduce this on Firefox, on both Mac and Android.

This PR adds `type="button"` to the clear button to prevent this behaviour.