### PR TITLE
Added 'defaults' browserslist to emoji-mart package.json

### DIFF
--- a/packages/emoji-mart/package.json
+++ b/packages/emoji-mart/package.json
@@ -15,6 +15,7 @@
   "type": "module",
   "source": "src/index.js",
   "main": "dist/index.js",
+  "browserslist": "defaults",
   "targets": {
     "main": {
       "includeNodeModules": true


### PR DESCRIPTION
Fixes #613 
Fixes #602 
Fixes #582 

Added `browserslist` as `defaults` to package.json of `emoji-mart` package. This makes sure that the code is transpiled to support wider range of browsers.

Quoting from [parcel](https://parceljs.org/getting-started/webapp/#declaring-browser-targets):
>  By default Parcel does not perform any code transpilation. This means that if you write your code using modern language features, that’s what Parcel will output. You can declare your app’s supported browsers using the browserslist field. When this field is declared, Parcel will transpile your code accordingly to ensure compatibility with your supported browsers.

Having a `browserslist` key in package.json has the additional benefit of specifying which all browsers the current version of the package supports. Keeping it as `defaults` makes sure it is as per the current standards.

I have tested out the build locally, I can confirm that it transpiles properly in the project that we are working on.

@EtienneLem, please have a look into this issue. We had to resort to the v3 of this package for multiple projects due to this persisting issue.