### PR TITLE
Allow to use an id for custom categories

### DIFF
--- a/packages/emoji-mart/src/config.js
+++ b/packages/emoji-mart/src/config.js
@@ -66,7 +66,9 @@ async function _init(props) {
 
       if (!category.emojis || !category.emojis.length) continue
 
-      category.id = `custom_${i + 1}`
+      if (!category.id) {
+        category.id = `custom_${i + 1}`
+      }
       category.name || (category.name = I18n.categories.custom)
 
       if (prevCategory && !category.icon) {

--- a/packages/emoji-mart/src/config.js
+++ b/packages/emoji-mart/src/config.js
@@ -66,9 +66,7 @@ async function _init(props) {
 
       if (!category.emojis || !category.emojis.length) continue
 
-      if (!category.id) {
-        category.id = `custom_${i + 1}`
-      }
+      category.id || (category.id = `custom_${i + 1}`)
       category.name || (category.name = I18n.categories.custom)
 
       if (prevCategory && !category.icon) {


### PR DESCRIPTION
When I add a custom emoji category, I cannot indicate a custom id, so a default one is used what is a bit uncomfortable when I have to fill the categories array.

Current case:

```
init({
    ...,
    custom: [{ name: "Basic", emojis: [ … ] }],
    categories: ["custom_1"]
})
```

After this change:

```
init({
    ...,
    custom: [{ id: "basic", name: "Basic", emojis: [ … ] }],
    categories: ["basic"]
})
```