### PR TITLE
Make selected emoji accessible to screen readers

### DIFF
--- a/packages/emoji-mart/src/components/Picker/Picker.js
+++ b/packages/emoji-mart/src/components/Picker/Picker.js
@@ -964,6 +964,13 @@ export default class Picker extends Component {
     )
   }
 
+  renderLiveRegion() {
+    const emoji = this.getEmojiByPos(this.state.pos)
+    const contents = emoji ? emoji.name : ''
+
+    return <div aria-live="polite">{contents}</div>
+  }
+
   renderSkins() {
     const skinToneButton = this.refs.skinToneButton.current
     const skinToneButtonRect = skinToneButton.getBoundingClientRect()
@@ -1076,6 +1083,7 @@ export default class Picker extends Component {
         {this.props.navPosition == 'bottom' && this.renderNav()}
         {this.props.previewPosition == 'bottom' && this.renderPreview()}
         {this.state.showSkins && this.renderSkins()}
+        {this.renderLiveRegion()}
       </section>
     )
   }

--- a/packages/emoji-mart/src/components/Picker/Picker.js
+++ b/packages/emoji-mart/src/components/Picker/Picker.js
@@ -968,7 +968,11 @@ export default class Picker extends Component {
     const emoji = this.getEmojiByPos(this.state.pos)
     const contents = emoji ? emoji.name : ''
 
-    return <div aria-live="polite">{contents}</div>
+    return (
+      <div aria-live="polite" class="sr-only">
+        {contents}
+      </div>
+    )
   }
 
   renderSkins() {

--- a/packages/emoji-mart/src/components/Picker/PickerStyles.scss
+++ b/packages/emoji-mart/src/components/Picker/PickerStyles.scss
@@ -122,6 +122,15 @@
   text-overflow: ellipsis;
 }
 
+.sr-only {
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
 a {
   cursor: pointer;
   color: rgb(var(--em-rgb-accent));


### PR DESCRIPTION
## Problem

Users can navigate emojis using the arrow keys on their keyboards. Unfortunately, this behavior does not announce to screen reader users what the currently selected emoji is.

## Solution

Add an [ARIA live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) only visible to screen readers (hidden from the UI) that announces the currently selected emoji.

## Demo

This can be tested using a screen reader like VoiceOver on the Mac 👇

![CleanShot 2022-08-10 at 14 12 28](https://user-images.githubusercontent.com/44473/184021831-76796011-374c-47f7-aad6-887680188b01.gif)
