### PR TITLE
Add "part" to root element to allow overriding CSS variables

### DIFF
--- a/packages/emoji-mart/src/components/Picker/Picker.js
+++ b/packages/emoji-mart/src/components/Picker/Picker.js
@@ -1051,6 +1051,7 @@ export default class Picker extends Component {
     return (
       <section
         id="root"
+        part="root"
         class="flex flex-column"
         style={{
           width: this.props.perLine * this.props.emojiButtonSize + (12 + 16),


### PR DESCRIPTION
This allows you to do something like this to override CSS variables in `emoji-mart`:

```css
em-emoji-picker::part(root) {
    --em-rgb-background: '51, 51, 51';
}
```

Since it renders in the shadow DOM, I couldn't figure out another way to actually do these overrides.