### PR TITLE
Add optional ref to search input

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ function App() {
 | **skinTonePosition** | `preview` | `preview`, `search`, `none` | The position of the skin tone selector |
 | **theme** | `auto` | `auto`, `light`, `dark` | The color theme of the picker |
 | **getSpritesheetURL** | `null` | | A function that returns the URL of the spritesheet to use for the picker. It should be compatible with the data provided. |
+| **searchInputRef** | `null` | | Optional ref to pass to the search input |
 
 ### Custom emojis
 You can use custom emojis by providing an array of categories and their emojis. Emojis also support multiple skin tones and can be GIFs or SVGs.

--- a/packages/emoji-mart/src/components/Picker/Picker.js
+++ b/packages/emoji-mart/src/components/Picker/Picker.js
@@ -334,7 +334,8 @@ export default class Picker extends Component {
   }
 
   handleSearchInput = async () => {
-    const input = this.props.searchInputRef?.current ?? this.refs.searchInput.current
+    const input =
+      this.props.searchInputRef?.current ?? this.refs.searchInput.current
     if (!input) return
 
     const { value } = input
@@ -418,7 +419,8 @@ export default class Picker extends Component {
   }
 
   clearSearch = () => {
-    const input = this.props.searchInputRef?.current ?? this.refs.searchInput.current
+    const input =
+      this.props.searchInputRef?.current ?? this.refs.searchInput.current
     if (!input) return
 
     input.value = ''
@@ -428,7 +430,8 @@ export default class Picker extends Component {
   }
 
   unfocusSearch() {
-    const input = this.props.searchInputRef?.current ?? this.refs.searchInput.current
+    const input =
+      this.props.searchInputRef?.current ?? this.refs.searchInput.current
     if (!input) return
 
     input.blur()

--- a/packages/emoji-mart/src/components/Picker/Picker.js
+++ b/packages/emoji-mart/src/components/Picker/Picker.js
@@ -334,7 +334,7 @@ export default class Picker extends Component {
   }
 
   handleSearchInput = async () => {
-    const input = this.refs.searchInput.current
+    const input = this.props.searchInputRef?.current ?? this.refs.searchInput.current
     if (!input) return
 
     const { value } = input
@@ -418,7 +418,7 @@ export default class Picker extends Component {
   }
 
   clearSearch = () => {
-    const input = this.refs.searchInput.current
+    const input = this.props.searchInputRef?.current ?? this.refs.searchInput.current
     if (!input) return
 
     input.value = ''
@@ -428,7 +428,7 @@ export default class Picker extends Component {
   }
 
   unfocusSearch() {
-    const input = this.refs.searchInput.current
+    const input = this.props.searchInputRef?.current ?? this.refs.searchInput.current
     if (!input) return
 
     input.blur()
@@ -790,7 +790,7 @@ export default class Picker extends Component {
           <div class="search relative flex-grow">
             <input
               type="search"
-              ref={this.refs.searchInput}
+              ref={this.props.searchInputRef ?? this.refs.searchInput}
               placeholder={I18n.search}
               onClick={this.handleSearchClick}
               onInput={this.handleSearchInput}


### PR DESCRIPTION
We have a scenario where the search input can become unfocused, but then we have to focus it again. To do this, we need to be able to pass a ref to it.