### PR TITLE
Allow passing imageURL / spritesheetURL as specific props

### DIFF
--- a/packages/emoji-mart/src/components/Emoji/Emoji.js
+++ b/packages/emoji-mart/src/components/Emoji/Emoji.js
@@ -1,6 +1,34 @@
 import { Data } from '../../config'
 import { SearchIndex } from '../../helpers'
 
+const getImageSrc = (props, emojiSkin) => {
+  if (props.set === 'native' || props.spritesheet) {
+    return undefined
+  }
+
+  if (typeof props.getImageURL === 'function') {
+    return props.getImageURL(props.set, emojiSkin.unified)
+  }
+
+  if (typeof props.imageURL === 'string') {
+    return props.imageURL
+  }
+
+  return `https://cdn.jsdelivr.net/npm/emoji-datasource-${props.set}@14.0.0/img/${props.set}/64/${emojiSkin.unified}.png`
+}
+
+const getSpritesheetSrc = (props) => {
+  if (typeof props.getSpritesheetURL === 'function') {
+    return props.getSpritesheetURL(props.set)
+  }
+
+  if (typeof props.spritesheetURL === 'string') {
+    return props.spritesheetURL
+  }
+
+  return `https://cdn.jsdelivr.net/npm/emoji-datasource-${props.set}@14.0.0/img/${props.set}/sheets-256/64.png`
+}
+
 export default function Emoji(props) {
   let { id, skin, emoji } = props
 
@@ -21,18 +49,8 @@ export default function Emoji(props) {
 
   const emojiSkin = emoji.skins[skin - 1] || emoji.skins[0]
 
-  const imageSrc =
-    emojiSkin.src ||
-    (props.set != 'native' && !props.spritesheet
-      ? typeof props.getImageURL === 'function'
-        ? props.getImageURL(props.set, emojiSkin.unified)
-        : `https://cdn.jsdelivr.net/npm/emoji-datasource-${props.set}@14.0.0/img/${props.set}/64/${emojiSkin.unified}.png`
-      : undefined)
-
-  const spritesheetSrc =
-    typeof props.getSpritesheetURL === 'function'
-      ? props.getSpritesheetURL(props.set)
-      : `https://cdn.jsdelivr.net/npm/emoji-datasource-${props.set}@14.0.0/img/${props.set}/sheets-256/64.png`
+  const imageSrc = getImageSrc(props, emojiSkin)
+  const spritesheetSrc = getSpritesheetSrc(props)
 
   return (
     <span class="emoji-mart-emoji" data-emoji-set={props.set}>

--- a/packages/emoji-mart/src/components/Emoji/Emoji.js
+++ b/packages/emoji-mart/src/components/Emoji/Emoji.js
@@ -3,7 +3,7 @@ import { SearchIndex } from '../../helpers'
 
 const getImageSrc = (props, emojiSkin) => {
   if (emojiSkin.src) {
-    return emojiSkin.src;
+    return emojiSkin.src
   }
 
   if (props.set === 'native' || props.spritesheet) {

--- a/packages/emoji-mart/src/components/Emoji/Emoji.js
+++ b/packages/emoji-mart/src/components/Emoji/Emoji.js
@@ -2,6 +2,10 @@ import { Data } from '../../config'
 import { SearchIndex } from '../../helpers'
 
 const getImageSrc = (props, emojiSkin) => {
+  if (emojiSkin.src) {
+    return emojiSkin.src;
+  }
+
   if (props.set === 'native' || props.spritesheet) {
     return undefined
   }

--- a/packages/emoji-mart/src/components/Emoji/EmojiProps.js
+++ b/packages/emoji-mart/src/components/Emoji/EmojiProps.js
@@ -17,6 +17,10 @@ export default {
     },
   },
 
+  imageURL: null,
+  spritesheetURL: null,
+  spritesheet: null,
+
   // Shared
   set: PickerProps.set,
   skin: PickerProps.skin,


### PR DESCRIPTION
Fixes #697

Web components can only take in strings as props (see https://stackoverflow.com/questions/50865614/can-i-pass-function-as-attribute-to-web-component)

When you pass the `em-emoji` component a function for `getImageURL` / `getSpritesheetURL` they actually end up being `null` so this will always return `null`:

https://github.com/missive/emoji-mart/blob/2054b155cac965bb432ca6b6cd70b51304f8ed7f/packages/emoji-mart/src/config.js#L260-L264

This PR adds `imageURL` / `spritesheetURL` props that can be passed in as strings instead.

Another solution could be to export an `Emoji` component from `@emoji-mart/react` which will properly handle the function as a prop. The downside there is that the `em-emoji` web component won't really be fully usable (or it should at least be documented that it doesn't support any props that are functions)

It almost seems like the `getImageURL` / `getSpritesheetURL` props should be removed as options altogether 🤔