### PR TITLE
Use maxWidth / maxHeight for image Emoji

### DIFF
--- a/packages/emoji-mart/src/components/Emoji/Emoji.js
+++ b/packages/emoji-mart/src/components/Emoji/Emoji.js
@@ -39,8 +39,8 @@ export default function Emoji(props) {
       {imageSrc ? (
         <img
           style={{
-            height: props.size || '1em',
-            width: 'auto',
+            maxWidth: props.size || '1em',
+            maxHeight: props.size || '1em',
             display: 'inline-block',
             position: 'relative',
             top: '.1em',


### PR DESCRIPTION
We noticed that with non-square custom emoji, they would overlap each other.

By using `maxWidth` / `maxHeight` here, they will still be the right size but will not expand beyond the `size` passed in to props.