### PR TITLE
Remove optional chaining

### DIFF
--- a/packages/emoji-mart/src/components/HTMLElement/HTMLElement.ts
+++ b/packages/emoji-mart/src/components/HTMLElement/HTMLElement.ts
@@ -1,7 +1,10 @@
 // @ts-nocheck
 import { getProp } from '../../config'
 
-const WindowHTMLElement = window?.HTMLElement ?? Object
+const WindowHTMLElement =
+  typeof window !== 'undefined' && window.HTMLElement
+    ? window.HTMLElement
+    : Object
 
 export default class HTMLElement extends WindowHTMLElement {
   static get observedAttributes() {


### PR DESCRIPTION
Not supported by older versions of Webpack
Fixes #727