### PR TITLE
Relay event arg to `onClickOutside` callback

### DIFF
--- a/packages/emoji-mart/src/components/Picker/Picker.tsx
+++ b/packages/emoji-mart/src/components/Picker/Picker.tsx
@@ -219,7 +219,7 @@ export default class Picker extends Component {
       }
 
       if (this.props.onClickOutside) {
-        this.props.onClickOutside()
+        this.props.onClickOutside(e)
       }
     }
   }


### PR DESCRIPTION
This allows the callback to filter target elements.

### Sample issue scenario
Given:
- A custom trigger callback that opens the picker popup.
- And then the `onClickOutside` callback set to close the popup on outside clicks.

Issue: Without excluding the trigger element target in the `onClickOutside` callback, the popup is opened by the first callback and then closed instantly by the second callback, as it is registered as an outside click.
