### PR TITLE
Add `exceptEmojis` props

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ function App() {
 | **emojiButtonSize** | `36` | | The size of the emoji buttons |
 | **emojiSize** | `24` | | The size of the emojis (inside the buttons) |
 | **emojiVersion** | `14` | `1`, `2`, `3`, `4`, `5`, `11`, `12`, `12.1`, `13`, `13.1`, `14` | The version of the emoji data to use. Latest version supported in `@emoji-mart/data` is currently [14](https://emojipedia.org/emoji-14.0) |
-| **exceptEmojis** | `[]` | | The list of emoji ids that want to be except showing from emojis list |
+| **exceptEmojis** | `[]` | | List of emoji IDs that will be excluded from the picker |
 | **icons** | `auto` | `auto`, `outline`, `solid` | The type of icons to use for the picker. `outline` with light theme and `solid` with dark theme. |
 | **locale** | `en` | `en`, `ar`, `be`, `cs`, `de`, `es`, `fa`, `fi`, `fr`, `hi`, `it`, `ja`, `kr`, `nl`, `pl`, `pt`, `ru`, `sa`, `tr`, `uk`, `vi`, `zh` | The locale to use for the picker |
 | **maxFrequentRows** | `4` | | The maximum number of frequent rows to show. `0` will disable frequent category |

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ function App() {
 | **emojiButtonSize** | `36` | | The size of the emoji buttons |
 | **emojiSize** | `24` | | The size of the emojis (inside the buttons) |
 | **emojiVersion** | `14` | `1`, `2`, `3`, `4`, `5`, `11`, `12`, `12.1`, `13`, `13.1`, `14` | The version of the emoji data to use. Latest version supported in `@emoji-mart/data` is currently [14](https://emojipedia.org/emoji-14.0) |
+| **exceptEmojis** | `[]` | | The list of emoji ids that want to be except showing from emojis list |
 | **icons** | `auto` | `auto`, `outline`, `solid` | The type of icons to use for the picker. `outline` with light theme and `solid` with dark theme. |
 | **locale** | `en` | `en`, `ar`, `be`, `cs`, `de`, `es`, `fa`, `fi`, `fr`, `hi`, `it`, `ja`, `kr`, `nl`, `pl`, `pt`, `ru`, `sa`, `tr`, `uk`, `vi`, `zh` | The locale to use for the picker |
 | **maxFrequentRows** | `4` | | The maximum number of frequent rows to show. `0` will disable frequent category |

--- a/packages/emoji-mart-website/index.html
+++ b/packages/emoji-mart-website/index.html
@@ -300,6 +300,7 @@
         searchPosition: localStorage.searchPosition,
         skinTonePosition: localStorage.skinTonePosition,
         onEmojiSelect: console.log,
+        exceptEmojis: ['hankey'],
         custom: [
           {
             emojis: [

--- a/packages/emoji-mart-website/index.html
+++ b/packages/emoji-mart-website/index.html
@@ -300,7 +300,6 @@
         searchPosition: localStorage.searchPosition,
         skinTonePosition: localStorage.skinTonePosition,
         onEmojiSelect: console.log,
-        exceptEmojis: ['hankey'],
         custom: [
           {
             emojis: [

--- a/packages/emoji-mart/README.md
+++ b/packages/emoji-mart/README.md
@@ -100,6 +100,7 @@ function App() {
 | **emojiButtonSize** | `36` | | The size of the emoji buttons |
 | **emojiSize** | `24` | | The size of the emojis (inside the buttons) |
 | **emojiVersion** | `14` | `1`, `2`, `3`, `4`, `5`, `11`, `12`, `12.1`, `13`, `13.1`, `14` | The version of the emoji data to use. Latest version supported in `@emoji-mart/data` is currently [14](https://emojipedia.org/emoji-14.0) |
+| **exceptEmojis** | `[]` | | The list of emoji ids that want to be except showing from emojis list |
 | **icons** | `auto` | `auto`, `outline`, `solid` | The type of icons to use for the picker. `outline` with light theme and `solid` with dark theme. |
 | **locale** | `en` | `en`, `ar`, `de`, `es`, `fa`, `fr`, `it`, `ja`, `nl`, `pl`, `pt`, `ru`, `uk`, `zh` | The locale to use for the picker |
 | **maxFrequentRows** | `4` | | The maximum number of frequent rows to show. `0` will disable frequent category |

--- a/packages/emoji-mart/src/components/Picker/PickerProps.ts
+++ b/packages/emoji-mart/src/components/Picker/PickerProps.ts
@@ -21,6 +21,9 @@ export default {
     value: 14,
     choices: [1, 2, 3, 4, 5, 11, 12, 12.1, 13, 13.1, 14],
   },
+  exceptEmojis: {
+    value: [],
+  },
   icons: {
     value: 'auto',
     choices: ['auto', 'outline', 'solid'],

--- a/packages/emoji-mart/src/config.ts
+++ b/packages/emoji-mart/src/config.ts
@@ -195,6 +195,11 @@ async function _init(props) {
         }
       }
 
+      if (props.exceptEmojis.includes(emoji.id)) {
+        ignore()
+        continue
+      }
+
       if (!emoji.search) {
         resetSearchIndex = true
         emoji.search =

--- a/packages/emoji-mart/src/config.ts
+++ b/packages/emoji-mart/src/config.ts
@@ -178,7 +178,7 @@ async function _init(props) {
         category.emojis.splice(emojiIndex, 1)
       }
 
-      if (!emoji) {
+      if (!emoji || props.exceptEmojis.includes(emoji.id)) {
         ignore()
         continue
       }
@@ -193,11 +193,6 @@ async function _init(props) {
           ignore()
           continue
         }
-      }
-
-      if (props.exceptEmojis.includes(emoji.id)) {
-        ignore()
-        continue
       }
 
       if (!emoji.search) {


### PR DESCRIPTION
Add `exceptEmojis` props to excepting some custom emojis that don't wants showing to emojis list

for example:
```js
exceptEmojis: ['hankey'],
```