### PR TITLE
Support customization for Preview Placeholder Size

### DIFF
--- a/packages/emoji-mart/src/components/Picker/PickerStyles.scss
+++ b/packages/emoji-mart/src/components/Picker/PickerStyles.scss
@@ -46,7 +46,7 @@
 
   --sidebar-width: 16px;
 
-  --preview-placeholder-size: 21px;
+  --em-preview-placeholder-size: var(--preview-placeholder-size, 21px);
   --preview-title-size: 1.1em;
   --preview-subtitle-size: .9em;
 
@@ -323,7 +323,7 @@ button {
   padding: calc(var(--padding) + 4px) var(--padding);
   padding-right: var(--sidebar-width);
 
-  .preview-placeholder { font-size: var(--preview-placeholder-size) }
+  .preview-placeholder { font-size: var(--em-preview-placeholder-size) }
   .preview-title { font-size: var(--preview-title-size) }
   .preview-subtitle { font-size: var(--preview-subtitle-size) }
 }


### PR DESCRIPTION
This PR enables the overwrite of the CSS variable `preview-placeholder-size`