### PR TITLE
Make `exceptEmojis` optional when calling `init`

### DIFF
--- a/packages/emoji-mart/src/config.ts
+++ b/packages/emoji-mart/src/config.ts
@@ -178,7 +178,7 @@ async function _init(props) {
         category.emojis.splice(emojiIndex, 1)
       }
 
-      if (!emoji || props.exceptEmojis.includes(emoji.id)) {
+      if (!emoji || props.exceptEmojis?.includes(emoji.id)) {
         ignore()
         continue
       }

--- a/packages/emoji-mart/src/config.ts
+++ b/packages/emoji-mart/src/config.ts
@@ -178,7 +178,10 @@ async function _init(props) {
         category.emojis.splice(emojiIndex, 1)
       }
 
-      if (!emoji || props.exceptEmojis?.includes(emoji.id)) {
+      if (
+        !emoji ||
+        (props.exceptEmojis && props.exceptEmojis.includes(emoji.id))
+      ) {
         ignore()
         continue
       }


### PR DESCRIPTION
```ts
import data from "@emoji-mart/data";
import { init } from "emoji-mart";

init({ data });
```

Before: `TypeError: undefined is not an object (evaluating 'props.exceptEmojis.includes')`

After: ✅ 