### PR TITLE
Use 16px font size in search input to prevent mobile viewport zoom

### DIFF
--- a/packages/emoji-mart/src/components/Picker/PickerStyles.scss
+++ b/packages/emoji-mart/src/components/Picker/PickerStyles.scss
@@ -234,6 +234,7 @@ a {
     transition-duration: var(--duration);
     transition-property: background-color, box-shadow;
     transition-timing-function: var(--easing);
+    font-size: 16px;
 
     &::placeholder {
       color: inherit;


### PR DESCRIPTION
When an input's text is is smaller than 16px, mobile browsers like iOS Safari will zoom the viewport when the input is focused.

This change sets the search input's default size to 16px to avoid the jarring zoom interaction. Because this is difficult to override with custom CSS, or in React by overriding CSS variables, it seemed like the fastest win to make this input have 16px font-size by default.