### PR TITLE
Add styleProps prop

### DIFF
--- a/packages/emoji-mart/src/components/HTMLElement/ShadowElement.ts
+++ b/packages/emoji-mart/src/components/HTMLElement/ShadowElement.ts
@@ -19,6 +19,10 @@ export default class ShadowElement extends HTMLElement {
     const style = document.createElement('style')
     style.textContent = styles
 
+    Object.entries(this.props.styleProps || {}).forEach(([key, value]) => {
+      style.setAttribute(key, value)
+    })
+
     this.shadowRoot.insertBefore(style, this.shadowRoot.firstChild)
   }
 }

--- a/packages/emoji-mart/src/components/Picker/PickerProps.ts
+++ b/packages/emoji-mart/src/components/Picker/PickerProps.ts
@@ -94,6 +94,9 @@ export default {
     value: 'preview',
     choices: ['preview', 'search', 'none'],
   },
+  styleProps: {
+    value: {},
+  },
   theme: {
     value: 'auto',
     choices: ['auto', 'light', 'dark'],


### PR DESCRIPTION
The style injection used in ShadowElement.tsx conflicts with content security policies that disallow inline stylesheets. To facilitate a workaround for this, this PR adds a `styleProps` prop to `PickerProps`, each key and value of which is added as a DOM attribute on the injected style element.

TypeScript seems to be disabled for most source files, so I don't know whether I've missed anything important in my implementation. I'll update this PR if I encounter any problems using the patch in production.