### PR TITLE
customizing styles

### DIFF
--- a/packages/emoji-mart-website/example-custom-styles.html
+++ b/packages/emoji-mart-website/example-custom-styles.html
@@ -22,6 +22,10 @@
         min-height: 400px;
         max-height: 800px;
       }
+
+      em-emoji-picker::part(search){
+        background-color: pink;
+      }
     </style>
   </block>
 

--- a/packages/emoji-mart/src/components/Navigation/Navigation.tsx
+++ b/packages/emoji-mart/src/components/Navigation/Navigation.tsx
@@ -89,6 +89,7 @@ export default class Navigation extends PureComponent {
 
           <div
             class="bar"
+            part="nav-bar"
             style={{
               width: `${100 / this.categories.length}%`,
               opacity: selectedCategoryIndex == null ? 0 : 1,

--- a/packages/emoji-mart/src/components/Picker/Picker.tsx
+++ b/packages/emoji-mart/src/components/Picker/Picker.tsx
@@ -692,6 +692,7 @@ export default class Picker extends Component {
     return (
       <div
         id="preview"
+        part="preview"
         class="flex flex-middle"
         dir={this.dir}
         data-position={this.props.previewPosition}
@@ -812,6 +813,7 @@ export default class Picker extends Component {
           <div class="search relative flex-grow">
             <input
               type="search"
+              part="search"
               ref={this.refs.searchInput}
               placeholder={I18n.search}
               onClick={this.handleSearchClick}
@@ -823,6 +825,7 @@ export default class Picker extends Component {
             {this.state.searchResults && (
               <button
                 title="Clear"
+                part="clear"
                 aria-label="Clear"
                 type="button"
                 class="icon delete flex"
@@ -1035,6 +1038,7 @@ export default class Picker extends Component {
     return (
       <div
         ref={this.refs.menu}
+        part="skin-tone-menu"
         role="radiogroup"
         dir={this.dir}
         aria-label={I18n.skins.choose}
@@ -1051,6 +1055,7 @@ export default class Picker extends Component {
               <input
                 type="radio"
                 name="skin-tone"
+                part="skin-tone-input"
                 value={skin}
                 aria-label={I18n.skins[skin]}
                 ref={checked ? this.refs.skinToneRadio : null}
@@ -1093,6 +1098,7 @@ export default class Picker extends Component {
       <section
         id="root"
         class="flex flex-column"
+        part="root"
         dir={this.dir}
         style={{
           width: this.props.dynamicWidth
@@ -1109,7 +1115,7 @@ export default class Picker extends Component {
           <div class="padding-lr">{this.renderSearch()}</div>
         )}
 
-        <div ref={this.refs.scroll} class="scroll flex-grow padding-lr">
+        <div ref={this.refs.scroll} class="scroll flex-grow padding-lr" part="scroll">
           <div
             style={{
               width: this.props.dynamicWidth ? '100%' : lineWidth,


### PR DESCRIPTION
Currently, customizing styles is kind of limited. User can change only `em-emoji-picker`.
This task includes customizing styles of other parts, including "Search" "Preview bar", "Underscore line of category tag icons" using [::part() CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/::part)