### PR TITLE
fix: conditionnally call super only when Element is object

### DIFF
--- a/packages/emoji-mart/src/components/HTMLElement/HTMLElement.ts
+++ b/packages/emoji-mart/src/components/HTMLElement/HTMLElement.ts
@@ -12,7 +12,7 @@ export default class HTMLElement extends WindowHTMLElement {
   }
 
   constructor(props = {}) {
-    if(WindowHTMLElement === Object){
+    if (WindowHTMLElement === Object) {
       super()
     }
 

--- a/packages/emoji-mart/src/components/HTMLElement/HTMLElement.ts
+++ b/packages/emoji-mart/src/components/HTMLElement/HTMLElement.ts
@@ -12,7 +12,10 @@ export default class HTMLElement extends WindowHTMLElement {
   }
 
   constructor(props = {}) {
-    super()
+    if(WindowHTMLElement === Object){
+      super()
+    }
+
     this.props = props
 
     if (props.parent || props.ref) {


### PR DESCRIPTION
HTMLElement doesn't allow calling super on it.