### PR TITLE
Expose a CSS variable to set the `cursor` property

### DIFF
--- a/packages/emoji-mart-website/example-custom-styles.html
+++ b/packages/emoji-mart-website/example-custom-styles.html
@@ -10,6 +10,7 @@
         --category-icon-size: 24px;
         --color-border-over: rgba(0, 0, 0, 0.1);
         --color-border: rgba(0, 0, 0, 0.05);
+        --cursor: pointer;
         --font-family: 'Comic Sans MS', 'Chalkboard SE', cursive;
         --font-size: 20px;
         --rgb-accent: 255, 105, 180;

--- a/packages/emoji-mart/src/components/Picker/PickerStyles.scss
+++ b/packages/emoji-mart/src/components/Picker/PickerStyles.scss
@@ -8,6 +8,7 @@
 
   --border-radius: 10px;
   --category-icon-size: 18px;
+  --cursor: pointer;
   --font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
   --font-size: 15px;
 
@@ -68,8 +69,8 @@
   background-color: rgb(var(--em-rgb-background));
 
   &[data-menu] {
-    button { cursor: auto }
-    .menu button { cursor: pointer }
+    button { cursor: var(--cursor) }
+    .menu button { cursor: var(--cursor) }
   }
 }
 
@@ -136,7 +137,7 @@
 }
 
 a {
-  cursor: pointer;
+  cursor: var(--cursor);
   color: rgb(var(--em-rgb-accent));
 
   &:hover { text-decoration: underline }
@@ -274,7 +275,7 @@ svg {
 
 button {
   appearance: none;
-  cursor: pointer;
+  cursor: var(--cursor);
   color: currentColor;
   border: 0;
   background-color: transparent;


### PR DESCRIPTION
Hi,

It'd be useful to expose a CSS variable for setting the `cursor` property, similar to `--font-size` for example. We, in our app have a user preference which, technically allows for setting the `cursor` property for interactive elements across the entire application for the user. Hoping that this resonates with some other users of the library as well.

Thanks for such a polished library :pray: 

Team @outline

cc: @tommoor