### PR TITLE
Modifications to allow Emoji-Mart to use custom fallback images, and properly respect provided image and spritesheet URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 coverage
 node_modules
 dist
+nbproject

--- a/packages/emoji-mart/src/components/Emoji/Emoji.tsx
+++ b/packages/emoji-mart/src/components/Emoji/Emoji.tsx
@@ -2,7 +2,7 @@ import { Data } from '../../config'
 import { SearchIndex } from '../../helpers'
 
 export default function Emoji(props) {
-  let { id, skin, emoji } = props
+  let { id, skin, emoji, imageURL, spritesheetURL, fallbackImageURL, fallbackSpritesheetURL } = props
 
   if (props.shortcodes) {
     const matches = props.shortcodes.match(SearchIndex.SHORTCODES_REGEX)
@@ -24,15 +24,11 @@ export default function Emoji(props) {
   const imageSrc =
     emojiSkin.src ||
     (props.set != 'native' && !props.spritesheet
-      ? typeof props.getImageURL === 'function'
-        ? props.getImageURL(props.set, emojiSkin.unified)
-        : `https://cdn.jsdelivr.net/npm/emoji-datasource-${props.set}@14.0.0/img/${props.set}/64/${emojiSkin.unified}.png`
-      : undefined)
-
-  const spritesheetSrc =
-    typeof props.getSpritesheetURL === 'function'
-      ? props.getSpritesheetURL(props.set)
-      : `https://cdn.jsdelivr.net/npm/emoji-datasource-${props.set}@14.0.0/img/${props.set}/sheets-256/64.png`
+      ? (imageURL !== null) ?
+        ? imageURL.replace("emojiskin-unified", emojiSkin.unified)
+  : fallbackImageURL.replace("emojiskin-unified", emojiSkin.unified) : undefined)
+  
+  const spritesheetSrc = spritesheetURL !== null ? spritesheetURL: fallbackSpritesheetURL
 
   return (
     <span class="emoji-mart-emoji" data-emoji-set={props.set}>

--- a/packages/emoji-mart/src/components/Emoji/EmojiElement.jsx
+++ b/packages/emoji-mart/src/components/Emoji/EmojiElement.jsx
@@ -14,14 +14,19 @@ export default class EmojiElement extends HTMLElement {
 
   async connectedCallback() {
     const props = getProps(this.props, EmojiProps, this)
+    // These aren't needed at this point; including them only bloats the resulting HTML
+    this.removeAttribute('imageurl')
+    this.removeAttribute('spritesheeturl')
+    this.removeAttribute('fallbackimageurl')
+    this.removeAttribute('fallbackspritesheeturl')
     props.element = this
     props.ref = (component) => {
       this.component = component
     }
-
+    
     await init()
     if (this.disconnected) return
-
+    
     render(<Emoji {...props} />, this)
   }
 }

--- a/packages/emoji-mart/src/components/Emoji/EmojiProps.ts
+++ b/packages/emoji-mart/src/components/Emoji/EmojiProps.ts
@@ -20,4 +20,9 @@ export default {
   // Shared
   set: PickerProps.set,
   skin: PickerProps.skin,
+  // Added to ensure the Emoji object can access these parameters
+  imageURL: PickerProps.imageURL,
+  spritesheetURL: PickerProps.spritesheetURL,
+  fallbackImageURL: PickerProps.fallbackImageURL,
+  fallbackSpritesheetURL: PickerProps.fallbackSpritesheetURL,
 }

--- a/packages/emoji-mart/src/components/Picker/Picker.tsx
+++ b/packages/emoji-mart/src/components/Picker/Picker.tsx
@@ -692,7 +692,7 @@ export default class Picker extends Component {
     return (
       <div
         id="preview"
-        class="flex flex-middle"
+  class="flex flex-middle"
         dir={this.dir}
         data-position={this.props.previewPosition}
       >
@@ -718,7 +718,10 @@ export default class Picker extends Component {
               size={this.props.emojiButtonSize}
               skin={this.state.tempSkin || this.state.skin}
               spritesheet={true}
-              getSpritesheetURL={this.props.getSpritesheetURL}
+              imageURL={this.props.imageURL}
+              spritesheetURL={this.props.spritesheetURL}
+              fallbackImageURL={this.props.fallbackImageURL}
+              fallbackSpritesheetURL={this.props.fallbackSpritesheetURL}
             />
           </div>
 
@@ -763,7 +766,7 @@ export default class Picker extends Component {
           data-keyboard={this.state.keyboard}
           title={this.props.previewPosition == 'none' ? emoji.name : undefined}
           type="button"
-          class="flex flex-center flex-middle"
+  class="flex flex-center flex-middle"
           tabindex="-1"
           onClick={(e) => this.handleEmojiClick({ e, emoji })}
           onMouseEnter={() => this.handleEmojiOver(pos)}
@@ -793,7 +796,10 @@ export default class Picker extends Component {
             size={this.props.emojiSize}
             skin={skin}
             spritesheet={true}
-            getSpritesheetURL={this.props.getSpritesheetURL}
+            imageURL={this.props.imageURL}
+            spritesheetURL={this.props.spritesheetURL}
+            fallbackImageURL={this.props.fallbackImageURL}
+            fallbackSpritesheetURL={this.props.fallbackSpritesheetURL}
           />
         </button>
       </PureInlineComponent>

--- a/packages/emoji-mart/src/components/Picker/Picker.tsx
+++ b/packages/emoji-mart/src/components/Picker/Picker.tsx
@@ -692,7 +692,7 @@ export default class Picker extends Component {
     return (
       <div
         id="preview"
-  class="flex flex-middle"
+        class="flex flex-middle"
         dir={this.dir}
         data-position={this.props.previewPosition}
       >

--- a/packages/emoji-mart/src/components/Picker/Picker.tsx
+++ b/packages/emoji-mart/src/components/Picker/Picker.tsx
@@ -766,7 +766,7 @@ export default class Picker extends Component {
           data-keyboard={this.state.keyboard}
           title={this.props.previewPosition == 'none' ? emoji.name : undefined}
           type="button"
-  class="flex flex-center flex-middle"
+          class="flex flex-center flex-middle"
           tabindex="-1"
           onClick={(e) => this.handleEmojiClick({ e, emoji })}
           onMouseEnter={() => this.handleEmojiOver(pos)}

--- a/packages/emoji-mart/src/components/Picker/PickerProps.ts
+++ b/packages/emoji-mart/src/components/Picker/PickerProps.ts
@@ -1,123 +1,123 @@
 export default {
-    autoFocus: {
-        value: false,
-    },
-    dynamicWidth: {
-        value: false,
-    },
-    emojiButtonColors: {
-        value: null,
-    },
-    emojiButtonRadius: {
-        value: '100%',
-    },
-    emojiButtonSize: {
-        value: 36,
-    },
-    emojiSize: {
-        value: 24,
-    },
-    emojiVersion: {
-        value: 14,
-        choices: [1, 2, 3, 4, 5, 11, 12, 12.1, 13, 13.1, 14],
-    },
-    exceptEmojis: {
-        value: [],
-    },
-    icons: {
-        value: 'auto',
-        choices: ['auto', 'outline', 'solid'],
-    },
-    locale: {
-        value: 'en',
-        choices: [
-            'en',
-            'ar',
-            'be',
-            'cs',
-            'de',
-            'es',
-            'fa',
-            'fi',
-            'fr',
-            'hi',
-            'it',
-            'ja',
-            'kr',
-            'nl',
-            'pl',
-            'pt',
-            'ru',
-            'sa',
-            'tr',
-            'uk',
-            'vi',
-            'zh',
-        ],
-    },
-    maxFrequentRows: {
-        value: 4,
-    },
-    navPosition: {
-        value: 'top',
-        choices: ['top', 'bottom', 'none'],
-    },
-    noCountryFlags: {
-        value: false,
-    },
-    noResultsEmoji: {
-        value: null,
-    },
-    perLine: {
-        value: 9,
-    },
-    previewEmoji: {
-        value: null,
-    },
-    previewPosition: {
-        value: 'bottom',
-        choices: ['top', 'bottom', 'none'],
-    },
-    searchPosition: {
-        value: 'sticky',
-        choices: ['sticky', 'static', 'none'],
-    },
-    set: {
-        value: 'native',
-        choices: ['native', 'apple', 'facebook', 'google', 'twitter'],
-    },
-    skin: {
-        value: 1,
-        choices: [1, 2, 3, 4, 5, 6],
-    },
-    skinTonePosition: {
-        value: 'preview',
-        choices: ['preview', 'search', 'none'],
-    },
-    theme: {
-        value: 'auto',
-        choices: ['auto', 'light', 'dark'],
-    },
+  autoFocus: {
+    value: false,
+  },
+  dynamicWidth: {
+    value: false,
+  },
+  emojiButtonColors: {
+    value: null,
+  },
+  emojiButtonRadius: {
+    value: '100%',
+  },
+  emojiButtonSize: {
+    value: 36,
+  },
+  emojiSize: {
+    value: 24,
+  },
+  emojiVersion: {
+    value: 14,
+    choices: [1, 2, 3, 4, 5, 11, 12, 12.1, 13, 13.1, 14],
+  },
+  exceptEmojis: {
+    value: [],
+  },
+  icons: {
+    value: 'auto',
+    choices: ['auto', 'outline', 'solid'],
+  },
+  locale: {
+    value: 'en',
+    choices: [
+      'en',
+      'ar',
+      'be',
+      'cs',
+      'de',
+      'es',
+      'fa',
+      'fi',
+      'fr',
+      'hi',
+      'it',
+      'ja',
+      'kr',
+      'nl',
+      'pl',
+      'pt',
+      'ru',
+      'sa',
+      'tr',
+      'uk',
+      'vi',
+      'zh',
+    ],
+  },
+  maxFrequentRows: {
+    value: 4,
+  },
+  navPosition: {
+    value: 'top',
+    choices: ['top', 'bottom', 'none'],
+  },
+  noCountryFlags: {
+    value: false,
+  },
+  noResultsEmoji: {
+    value: null,
+  },
+  perLine: {
+    value: 9,
+  },
+  previewEmoji: {
+    value: null,
+  },
+  previewPosition: {
+    value: 'bottom',
+    choices: ['top', 'bottom', 'none'],
+  },
+  searchPosition: {
+    value: 'sticky',
+    choices: ['sticky', 'static', 'none'],
+  },
+  set: {
+    value: 'native',
+    choices: ['native', 'apple', 'facebook', 'google', 'twitter'],
+  },
+  skin: {
+    value: 1,
+    choices: [1, 2, 3, 4, 5, 6],
+  },
+  skinTonePosition: {
+    value: 'preview',
+    choices: ['preview', 'search', 'none'],
+  },
+  theme: {
+    value: 'auto',
+    choices: ['auto', 'light', 'dark'],
+  },
 
-    // Data
-    categories: null,
-    categoryIcons: null,
-    custom: null,
-    data: null,
-    i18n: null,
-    imageURL: null,
-    spritesheetURL: null,
-    fallbackImageURL: null,
-    fallbackSpritesheetURL: null,
+  // Data
+  categories: null,
+  categoryIcons: null,
+  custom: null,
+  data: null,
+  i18n: null,
+  imageURL: null,
+  spritesheetURL: null,
+  fallbackImageURL: null,
+  fallbackSpritesheetURL: null,
 
-    // Callbacks
-    onAddCustomEmoji: null,
-    onClickOutside: null,
-    onEmojiSelect: null,
+  // Callbacks
+  onAddCustomEmoji: null,
+  onClickOutside: null,
+  onEmojiSelect: null,
 
-    // Deprecated
-    stickySearch: {
-        deprecated: true,
-        value: true,
-    },
+  // Deprecated
+  stickySearch: {
+    deprecated: true,
+    value: true,
+  },
 }

--- a/packages/emoji-mart/src/components/Picker/PickerProps.ts
+++ b/packages/emoji-mart/src/components/Picker/PickerProps.ts
@@ -1,121 +1,123 @@
 export default {
-  autoFocus: {
-    value: false,
-  },
-  dynamicWidth: {
-    value: false,
-  },
-  emojiButtonColors: {
-    value: null,
-  },
-  emojiButtonRadius: {
-    value: '100%',
-  },
-  emojiButtonSize: {
-    value: 36,
-  },
-  emojiSize: {
-    value: 24,
-  },
-  emojiVersion: {
-    value: 14,
-    choices: [1, 2, 3, 4, 5, 11, 12, 12.1, 13, 13.1, 14],
-  },
-  exceptEmojis: {
-    value: [],
-  },
-  icons: {
-    value: 'auto',
-    choices: ['auto', 'outline', 'solid'],
-  },
-  locale: {
-    value: 'en',
-    choices: [
-      'en',
-      'ar',
-      'be',
-      'cs',
-      'de',
-      'es',
-      'fa',
-      'fi',
-      'fr',
-      'hi',
-      'it',
-      'ja',
-      'kr',
-      'nl',
-      'pl',
-      'pt',
-      'ru',
-      'sa',
-      'tr',
-      'uk',
-      'vi',
-      'zh',
-    ],
-  },
-  maxFrequentRows: {
-    value: 4,
-  },
-  navPosition: {
-    value: 'top',
-    choices: ['top', 'bottom', 'none'],
-  },
-  noCountryFlags: {
-    value: false,
-  },
-  noResultsEmoji: {
-    value: null,
-  },
-  perLine: {
-    value: 9,
-  },
-  previewEmoji: {
-    value: null,
-  },
-  previewPosition: {
-    value: 'bottom',
-    choices: ['top', 'bottom', 'none'],
-  },
-  searchPosition: {
-    value: 'sticky',
-    choices: ['sticky', 'static', 'none'],
-  },
-  set: {
-    value: 'native',
-    choices: ['native', 'apple', 'facebook', 'google', 'twitter'],
-  },
-  skin: {
-    value: 1,
-    choices: [1, 2, 3, 4, 5, 6],
-  },
-  skinTonePosition: {
-    value: 'preview',
-    choices: ['preview', 'search', 'none'],
-  },
-  theme: {
-    value: 'auto',
-    choices: ['auto', 'light', 'dark'],
-  },
+    autoFocus: {
+        value: false,
+    },
+    dynamicWidth: {
+        value: false,
+    },
+    emojiButtonColors: {
+        value: null,
+    },
+    emojiButtonRadius: {
+        value: '100%',
+    },
+    emojiButtonSize: {
+        value: 36,
+    },
+    emojiSize: {
+        value: 24,
+    },
+    emojiVersion: {
+        value: 14,
+        choices: [1, 2, 3, 4, 5, 11, 12, 12.1, 13, 13.1, 14],
+    },
+    exceptEmojis: {
+        value: [],
+    },
+    icons: {
+        value: 'auto',
+        choices: ['auto', 'outline', 'solid'],
+    },
+    locale: {
+        value: 'en',
+        choices: [
+            'en',
+            'ar',
+            'be',
+            'cs',
+            'de',
+            'es',
+            'fa',
+            'fi',
+            'fr',
+            'hi',
+            'it',
+            'ja',
+            'kr',
+            'nl',
+            'pl',
+            'pt',
+            'ru',
+            'sa',
+            'tr',
+            'uk',
+            'vi',
+            'zh',
+        ],
+    },
+    maxFrequentRows: {
+        value: 4,
+    },
+    navPosition: {
+        value: 'top',
+        choices: ['top', 'bottom', 'none'],
+    },
+    noCountryFlags: {
+        value: false,
+    },
+    noResultsEmoji: {
+        value: null,
+    },
+    perLine: {
+        value: 9,
+    },
+    previewEmoji: {
+        value: null,
+    },
+    previewPosition: {
+        value: 'bottom',
+        choices: ['top', 'bottom', 'none'],
+    },
+    searchPosition: {
+        value: 'sticky',
+        choices: ['sticky', 'static', 'none'],
+    },
+    set: {
+        value: 'native',
+        choices: ['native', 'apple', 'facebook', 'google', 'twitter'],
+    },
+    skin: {
+        value: 1,
+        choices: [1, 2, 3, 4, 5, 6],
+    },
+    skinTonePosition: {
+        value: 'preview',
+        choices: ['preview', 'search', 'none'],
+    },
+    theme: {
+        value: 'auto',
+        choices: ['auto', 'light', 'dark'],
+    },
 
-  // Data
-  categories: null,
-  categoryIcons: null,
-  custom: null,
-  data: null,
-  i18n: null,
+    // Data
+    categories: null,
+    categoryIcons: null,
+    custom: null,
+    data: null,
+    i18n: null,
+    imageURL: null,
+    spritesheetURL: null,
+    fallbackImageURL: null,
+    fallbackSpritesheetURL: null,
 
-  // Callbacks
-  getImageURL: null,
-  getSpritesheetURL: null,
-  onAddCustomEmoji: null,
-  onClickOutside: null,
-  onEmojiSelect: null,
+    // Callbacks
+    onAddCustomEmoji: null,
+    onClickOutside: null,
+    onEmojiSelect: null,
 
-  // Deprecated
-  stickySearch: {
-    deprecated: true,
-    value: true,
-  },
+    // Deprecated
+    stickySearch: {
+        deprecated: true,
+        value: true,
+    },
 }


### PR DESCRIPTION
Hi all - I have been figuring out how to make Emoji-Mart work without adding any React to my project (I know Emoji-Mart compiles with preact, but nonetheless).

These changes have a few purposes:
   - EmojiProps originally did not have any knowledge of the image and spritesheet URLs, causing it to invariably fall back to the hardcoded JSDelivr URLs. I'm not sure if this is something to do with not using React; partly it is likely to do with web components not being able to have functions as attributes. Therefore I have changed the getImageURL and getSpritesheetURL functions to imageURL and spritesheetURL strings, respectively. The imageURL string does not require a specific emoji code; it expects a URL in the form with "emojiskin-unified" in the name, and then replaces this text with the unified code.

  - PickerProps and EmojiProps now have fallback properties, so that instead of using the hardcoded JSDelivr URLs, the user can either supply those or (as a default) use no fallback. 

- The EmojiElement class now removes the imageURL, spritesheetURL, and associated fallback attributes prior to rendering in connectedCallback(). I have found these attributes aren't needed in the final HTML, and bloat the elements considerably (an issue when e.g. saving them to a database, and just a bit unsightedly in the final HTML).

I've built and tested this for my project, with only the browser.js script needed for both the picker and emoji elements to function correctly. 