### PR TITLE
Add custom frequently used emojis

### DIFF
--- a/packages/emoji-mart/src/components/Picker/Picker.tsx
+++ b/packages/emoji-mart/src/components/Picker/Picker.tsx
@@ -625,7 +625,7 @@ export default class Picker extends Component {
     if (emoji) {
       const emojiData = getEmojiData(emoji, { skinIndex: this.state.skin - 1 })
 
-      if (this.props.maxFrequentRows) {
+      if (!this.props.customFrequentlyUsed?.enabled && this.props.maxFrequentRows) {
         FrequentlyUsed.add(emojiData, this.props)
       }
 

--- a/packages/emoji-mart/src/components/Picker/PickerProps.ts
+++ b/packages/emoji-mart/src/components/Picker/PickerProps.ts
@@ -105,6 +105,7 @@ export default {
   custom: null,
   data: null,
   i18n: null,
+  customFrequentlyUsed:{enabled: false, values: []},
 
   // Callbacks
   getImageURL: null,

--- a/packages/emoji-mart/src/config.ts
+++ b/packages/emoji-mart/src/config.ts
@@ -145,7 +145,7 @@ async function _init(props) {
     const category = Data.categories[categoryIndex]
 
     if (category.id == 'frequent') {
-      let { maxFrequentRows, perLine } = props
+      let { maxFrequentRows, perLine, customFrequentlyUsed } = props
 
       maxFrequentRows =
         maxFrequentRows >= 0
@@ -153,7 +153,10 @@ async function _init(props) {
           : PickerProps.maxFrequentRows.value
       perLine || (perLine = PickerProps.perLine.value)
 
-      category.emojis = FrequentlyUsed.get({ maxFrequentRows, perLine })
+      if(customFrequentlyUsed?.enabled)
+        category.emojis = customFrequentlyUsed.values
+      else
+        category.emojis = FrequentlyUsed.get({ maxFrequentRows, perLine })
     }
 
     if (!category.emojis || !category.emojis.length) {


### PR DESCRIPTION
Add a prop for setting frequently used emojis

I have a common store for frequently used emojis across multiple platforms (Web/ Android/Desktop Client). I want to set the frequently used emojis when Picker is initialized

Referring to issue https://github.com/missive/emoji-mart/issues/847