### PR TITLE
Use `indexedDB` for persistant data

### DIFF
--- a/packages/emoji-mart/src/helpers/store.ts
+++ b/packages/emoji-mart/src/helpers/store.ts
@@ -15,9 +15,11 @@ function getIDB() {
         if (typeof msIndexedDB !== 'undefined') {
             return msIndexedDB;
         }
+      return;
     } catch (e) {
         return;
     }
+  
 }
 
 var idb = getIDB();
@@ -27,7 +29,7 @@ function getStore(callback, error) {
   db.onupgradeneeded = function () {
     db.result.createObjectStore("emoji-store");
   };
-  db.onsuccess = ({ result }) => {
+  db.onsuccess = ({ target: { result } }) => {
     const store = result
       .transaction("emoji-store", "readwrite")
       .objectStore("emoji-store");
@@ -51,7 +53,7 @@ function set(key: string, value: string) {
 }
 function get(key: string): any {
   try {
-    return runStoreCommand("get", `emoji-mart.${key}`, function ({ result }) {
+    return runStoreCommand("get", `emoji-mart.${key}`, function ({ target: { result } }) {
       return JSON.parse(result);
     });
   } catch (error) {}


### PR DESCRIPTION
With the regular localStorage implementation, people can access that very data and manipulate it to their likings. While this isn't necessarily a bad thing, it's safer for indexedDB to be used so its more private, plus, it doesn't mess with the user's already existing localStorage data.

Regards.