### PR TITLE
Update package.json with type module

### DIFF
--- a/packages/emoji-mart/package.json
+++ b/packages/emoji-mart/package.json
@@ -13,6 +13,7 @@
   "types": "dist/index.d.ts",
   "main": "dist/main.js",
   "module": "dist/module.js",
+  "type": "module",
   "global": "dist/browser.js",
   "browserslist": "defaults",
   "targets": {


### PR DESCRIPTION
Otherwise, emoji mart breaks on nodejs with following error:

> SyntaxError: Named export 'SearchIndex' not found. The requested module 'emoji-mart' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using: