### PR TITLE
Be able to go to category even while search is active

### DIFF
--- a/packages/emoji-mart/src/components/Picker/Picker.tsx
+++ b/packages/emoji-mart/src/components/Picker/Picker.tsx
@@ -607,7 +607,13 @@ export default class Picker extends Component {
   }
 
   handleCategoryClick = ({ category, i }) => {
-    this.scrollTo(i == 0 ? { row: -1 } : { categoryId: category.id })
+    if (this.state.searchResults) {
+      this.clearSearch()
+    }
+    this.unfocusSearch()
+    setTimeout(() => {
+      this.scrollTo(i == 0 ? { row: -1 } : { categoryId: category.id })
+    })
   }
 
   handleEmojiOver(pos) {


### PR DESCRIPTION
Solves https://github.com/missive/emoji-mart/issues/931

When clicking a category button, go to the category even if some search results are displayed.
Steps: clear the search, unfocus the search, and once all emojis are displayed, scroll to the expected category.

This PR proposes it as the default behavior, I can rework it as an option if you prefer.

Before:

https://github.com/user-attachments/assets/23d9bb50-0491-4871-97f7-b5629e62f2b9

After:

https://github.com/user-attachments/assets/5ac061f9-411a-4c42-8308-075a9d223dea