### PR TITLE
Add support for filter function

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ function App() {
 | **emojiSize** | `24` | | The size of the emojis (inside the buttons) |
 | **emojiVersion** | `14` | `1`, `2`, `3`, `4`, `5`, `11`, `12`, `12.1`, `13`, `13.1`, `14` | The version of the emoji data to use. Latest version supported in `@emoji-mart/data` is currently [14](https://emojipedia.org/emoji-14.0) |
 | **exceptEmojis** | `[]` | | List of emoji IDs that will be excluded from the picker |
+| **filterEmojis** | `undefined` | | A function that takes as parameter an emoji and returns a boolean (`true` if the emoji should be included, `false` if the emoji should be excluded) |
 | **icons** | `auto` | `auto`, `outline`, `solid` | The type of icons to use for the picker. `outline` with light theme and `solid` with dark theme. |
 | **locale** | `en` | `en`, `ar`, `be`, `cs`, `de`, `es`, `fa`, `fi`, `fr`, `hi`, `it`, `ja`, `ko`, `nl`, `pl`, `pt`, `ru`, `sa`, `tr`, `uk`, `vi`, `zh` | The locale to use for the picker |
 | **maxFrequentRows** | `4` | | The maximum number of frequent rows to show. `0` will disable frequent category |

--- a/packages/emoji-mart/src/components/Picker/PickerProps.ts
+++ b/packages/emoji-mart/src/components/Picker/PickerProps.ts
@@ -24,6 +24,7 @@ export default {
   exceptEmojis: {
     value: [],
   },
+  filterEmojis: undefined,
   icons: {
     value: 'auto',
     choices: ['auto', 'outline', 'solid'],

--- a/packages/emoji-mart/src/config.ts
+++ b/packages/emoji-mart/src/config.ts
@@ -180,7 +180,8 @@ async function _init(props) {
 
       if (
         !emoji ||
-        (props.exceptEmojis && props.exceptEmojis.includes(emoji.id))
+        (props.exceptEmojis && props.exceptEmojis.includes(emoji.id)) ||
+        (props.filterEmojis && !props.filterEmojis(emoji))
       ) {
         ignore()
         continue


### PR DESCRIPTION
This PR adds support to pass a filter function to the React component.

This enables users to determine what emojis to include/exclude with more granularity.

This can enable filtering by keywords, emoticons, shortcodes, emoji bytes, or any combination of these.