### PR TITLE
fix: reuse if there is already defined custom element

### DIFF
--- a/packages/emoji-mart-react/react.tsx
+++ b/packages/emoji-mart-react/react.tsx
@@ -11,6 +11,11 @@ export default function EmojiPicker(props) {
   }
 
   useEffect(() => {
+    const PickerElement = window?.customElements.get('em-emoji-picker')
+    if (PickerElement) {
+      instance.current = new PickerElement({ ...props, ref })
+      return
+    }
     instance.current = new Picker({ ...props, ref })
 
     return () => {


### PR DESCRIPTION
## Summary of Changes
- If a custom element(`em-emoji-picker`) is already defined, use it to create an instance.

## Reason for Changes
In `emoji-mart-react`, an instance is created using custom element(Picker) during initial rendering.
If my application has more than 2 packages using emoji-mart, I get into trouble in the following scenario.

1. When initializing `emoji-mart` in the first package, the custom element(em-emoji-picker) is defined because it has never been defined.
https://github.com/missive/emoji-mart/blob/16978d04a766eec6455e2e8bb21cd8dc0b3c7436/packages/emoji-mart/src/components/Picker/PickerElement.tsx#L30-L34
2. When initializing `emoji-mart` in the second package, the custom element(em-emoji-picker) is already defined, so it does not defined.
3. When initializing an instance using a custom element in the second package, **Illegal constructor error** occurs because the class used in the second package is not defined.

To fix this issue, I added guard logic to reuse custom element that is already defined.


## Issues
#812 
