### PR TITLE
Fix custom categories not showing up when using the categories prop

### DIFF
--- a/packages/emoji-mart/src/config.ts
+++ b/packages/emoji-mart/src/config.ts
@@ -97,6 +97,7 @@ async function _init(props) {
         ))
 
   if (props.custom) {
+    Data.customCategories = []
     for (let i in props.custom) {
       i = parseInt(i)
       const category = props.custom[i]
@@ -112,6 +113,7 @@ async function _init(props) {
       }
 
       Data.categories.push(category)
+      Data.customCategories.push(category)
 
       for (const emoji of category.emojis) {
         Data.emojis[emoji.id] = emoji
@@ -121,6 +123,11 @@ async function _init(props) {
 
   if (props.categories) {
     Data.categories = Data.originalCategories
+      .concat(
+        typeof Data.customCategories !== 'undefined'
+          ? Data.customCategories
+          : [],
+      )
       .filter((c) => {
         return props.categories.indexOf(c.id) != -1
       })


### PR DESCRIPTION
Fixes #951 and #959.

052badf added a new array to store the categories on first mount to filter on. Since the custom categories never pushed to it, they would never show up if the categories prop was used.

This just creates another array to store the custom categories, and makes the category prop filter on the combined original and custom categories.