### PR TITLE
fix: exclude parens from search name matching #962

### DIFF
--- a/packages/emoji-mart/src/config.ts
+++ b/packages/emoji-mart/src/config.ts
@@ -212,7 +212,7 @@ async function _init(props) {
               if (!strings) return
               return (Array.isArray(strings) ? strings : [strings])
                 .map((string) => {
-                  return (split ? string.split(/[-|_|\s]+/) : [string]).map(
+                  return (split ? string.split(/[-|_|\s()]+/) : [string]).map(
                     (s) => s.toLowerCase(),
                   )
                 })


### PR DESCRIPTION
Fixes #962 

| Name | Before | After |
|--------|--------|--------|
| `A Button (blood Type)` | `,a,button,(blood,type)` | `,a,button,blood,type` | 
| `Cocos (keeling) Islands Flag` | `,cocos,(keeling),islands,flag` | `,cocos,keeling,islands,flag` | 
