### PR TITLE
Use fully opaque pixels to determine if an emoji is supported

### DIFF
--- a/packages/emoji-mart/src/helpers/native-support.ts
+++ b/packages/emoji-mart/src/helpers/native-support.ts
@@ -83,7 +83,7 @@ const isEmojiSupported = (() => {
     let i = 0
 
     // Search the first visible pixel
-    for (; i < count && !a[i + 3]; i += 4);
+    for (; i < count && a[i + 3] < 255; i += 4);
 
     // No visible pixel
     if (i >= count) {


### PR DESCRIPTION
Fixes #970 by ensuring a fully opaque pixel is used for comparison, this avoids anti-aliasing discrepancies.