### PR TITLE
style: fix wrong TS syntax in data store

### DIFF
--- a/packages/emoji-mart/src/helpers/store.ts
+++ b/packages/emoji-mart/src/helpers/store.ts
@@ -1,4 +1,4 @@
-function set(key: string, value: string) {
+function set(key: string, value: any) {
   try {
     window.localStorage[`emoji-mart.${key}`] = JSON.stringify(value)
   } catch (error) {}


### PR DESCRIPTION
In my testing also non-striong objects were saved, but also `frequently` which is a JS object.