### PR TITLE
Fix index.d.ts by adding missing typings

### DIFF
--- a/packages/emoji-mart-data/index.d.ts
+++ b/packages/emoji-mart-data/index.d.ts
@@ -17,6 +17,7 @@ export interface Emoji {
   skins: Skin[]
   version: number
   emoticons?: string[]
+  search?: string
 }
 
 export interface Skin {
@@ -24,6 +25,7 @@ export interface Skin {
   native: string
   x?: number
   y?: number
+  shortcodes: string
 }
 
 export interface Sheet {


### PR DESCRIPTION
* `shortcodes` was missing from the skins
* I also found `search` 

Both found by analyzing the response from `SearchIndex.search`. Maybe this method however just adds/modifies the types?

Ref https://github.com/missive/emoji-mart/issues/576